### PR TITLE
docs: add docs/ and examples/

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1,0 +1,122 @@
+# Advanced
+
+Recipes, the rules behind the splits, and the rough edges to know about.
+
+## Digraphs that never split
+
+Five Portuguese digraphs represent a single sound and always stay in one
+syllable: `ch`, `lh`, `nh`, `gu`, `qu`. The algorithm keeps them intact.
+
+```python
+from silabificador import syllabify
+
+syllabify("chuva")    # ['chu', 'va']
+syllabify("filho")    # ['fi', 'lho']
+syllabify("vinho")    # ['vi', 'nho']
+syllabify("guerra")   # ['guer', 'ra']
+syllabify("quando")   # ['quan', 'do']
+```
+
+In `gu`/`qu` the `u` is usually silent, but before another consonant it behaves
+as a vowel and carries the nucleus — which is why `quando` splits as
+`quan-do`, not `qu-an-do`.
+
+## Onset clusters vs. clusters that split
+
+Consonant + liquid (`pr`, `br`, `tr`, `dr`, `cr`, `gr`, `fr`, `pl`, `bl`, `cl`,
+`gl`, `fl`) can start a syllable, so they travel together:
+
+```python
+syllabify("prato")    # ['pra', 'to']
+syllabify("flores")   # ['flo', 'res']
+```
+
+Other clusters break at the boundary:
+
+```python
+syllabify("carro")    # ['car', 'ro']   doubled 'rr'
+syllabify("pacto")    # ['pac', 'to']   'ct' is not a valid onset
+syllabify("ritmo")    # ['rit', 'mo']
+```
+
+## Diphthong vs. hiatus
+
+Two adjacent vowels are either one syllable (diphthong) or two (hiatus). The
+distinction is the hard part of Portuguese syllabification, and the library
+makes a conservative, benchmark-tuned choice.
+
+```python
+syllabify("pai")      # ['pai']            falling diphthong, one syllable
+syllabify("mãe")      # ['mãe']            nasal diphthong
+syllabify("saída")    # ['sa', 'í', 'da']  acute 'í' forces hiatus
+syllabify("coordenar")# ['co', 'or', 'de', 'nar']  repeated 'oo' is hiatus
+```
+
+To inspect a decision in isolation, reach for the predicates in
+`silabificador.syl`:
+
+```python
+from silabificador.syl import validate_diphthong, check_for_hiatus
+
+validate_diphthong("ai")                              # True
+validate_diphthong("ea")                              # False -> hiatus
+check_for_hiatus("ai", is_end=False, prev_char="r")   # True  -> split after r
+```
+
+These let you build your own reporting on top of the same rules the splitter
+uses.
+
+## Batch syllabification
+
+`syllabify` works on one word. For a list, map over it:
+
+```python
+from silabificador import syllabify
+
+words = ["computador", "história", "português", "água"]
+result = {w: syllabify(w) for w in words}
+for w, syls in result.items():
+    print(f"{w:14} {'-'.join(syls)}")
+```
+
+## Syllable count and stress position helpers
+
+The plain-list return makes downstream phonology easy. Counting syllables is
+`len(...)`; the penultimate syllable (the default stress position for many
+Portuguese words ending in a vowel) is `syls[-2]`:
+
+```python
+from silabificador import syllabify
+
+syls = syllabify("computador")
+print("syllables:", len(syls))         # 4
+print("last:", syls[-1])               # 'dor'  (oxytone: stress is final)
+
+syls = syllabify("casa")
+print("penult:", syls[-2])             # 'ca'   (paroxytone: stress is penult)
+```
+
+The library does not predict stress; it gives you the segmentation to compute it.
+
+## Gotchas
+
+- **Input is a single word.** A sentence should be tokenized first; a space is
+  treated as a compound hyphen, not a word separator with whitespace semantics.
+- **Output is lowercased.** Casing is normalized before splitting. Re-apply the
+  original case yourself if you need it.
+- **Foreign words** that do not follow Portuguese phonotactics may split
+  unexpectedly — the rules target native Portuguese.
+- **`Syllabifier` is stateless.** Constructing many of them buys nothing over
+  calling the function directly.
+
+## Sibling tooling
+
+`silabificador` produces orthographic syllables for the TigreGotico Portuguese
+NLP toolchain — segmentation that downstream phoneme and prosody components
+consume. It pairs naturally with grapheme-to-phoneme and lexicon components that
+expect words already split into syllables.
+
+## Where next
+
+- [quickstart.md](quickstart.md) — install and the core idea
+- [api.md](api.md) — full signatures and the constant tables

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,130 @@
+# API Reference
+
+Everything importable from `silabificador`, plus the validation helpers in
+`silabificador.syl`. Signatures and return shapes are exactly as implemented.
+
+## `syllabify`
+
+```python
+from silabificador import syllabify
+
+syllabify(word: str) -> List[str]
+```
+
+Divide a Portuguese word into syllables.
+
+- **word** — a single Portuguese word. Case is normalized to lowercase. A space
+  is treated as a hyphen, so a compound like `"guarda-chuva"` is processed as
+  hyphen-joined subwords. Leading/trailing whitespace is stripped.
+- **returns** — a list of syllable strings in order. Accents and digraphs are
+  preserved. `"".join(result)` reconstructs the lowercased input.
+
+```python
+syllabify("computador")     # ['com', 'pu', 'ta', 'dor']
+syllabify("Brasil")         # ['bra', 'sil']
+syllabify("português")      # ['por', 'tu', 'guês']
+```
+
+Edge cases handled directly:
+
+- A single printable character returns itself as a one-element list:
+  `syllabify(".") -> ['.']`.
+- The monosyllabic words `"ao"`, `"ui"`, `"ei"`, `"ai"` return as a single
+  syllable.
+
+## `Syllabifier`
+
+```python
+from silabificador import Syllabifier
+
+s = Syllabifier()
+s.syllabify(word: str) -> List[str]
+```
+
+A stateless object wrapper. `Syllabifier().syllabify(w)` is equivalent to
+`syllabify(w)`. Construct it with no arguments. Use it when an interface in your
+code expects an object that exposes a `.syllabify` method; otherwise call the
+function.
+
+```python
+Syllabifier().syllabify("caça")   # ['ca', 'ça']
+```
+
+## Validation helpers
+
+These live in `silabificador.syl` and back the boundary decisions inside
+`syllabify`. They are pure predicates — useful when you want to inspect why a
+vowel sequence does or does not stay in one syllable.
+
+### `validate_diphthong`
+
+```python
+from silabificador.syl import validate_diphthong
+
+validate_diphthong(diph: str, prev_char: str = "") -> bool
+```
+
+`True` if a two-character vowel sequence is a valid diphthong (one syllable),
+`False` if it is treated as hiatus or is not a vowel pair. An acute accent on
+the first vowel forces `False` (except `"áu"`); several sequences such as `"ea"`,
+`"io"`, `"ui"` are always treated as hiatus.
+
+```python
+validate_diphthong("ai")   # True
+validate_diphthong("ea")   # False
+validate_diphthong("ui")   # False
+```
+
+### `validate_triphthong`
+
+```python
+from silabificador.syl import validate_triphthong
+
+validate_triphthong(triph: str, prev_char: str = "") -> bool
+```
+
+`True` if a three-character vowel sequence is a valid triphthong (glide + vowel
++ glide, all in one syllable). The first character must be a semivowel; accents
+are allowed only on the middle vowel.
+
+```python
+validate_triphthong("uai")   # True  (as in Uruguai)
+validate_triphthong("eau")   # False
+```
+
+### `check_for_hiatus`
+
+```python
+from silabificador.syl import check_for_hiatus
+
+check_for_hiatus(diph: str, is_end: bool = False, prev_char: str = "") -> bool
+```
+
+Context-sensitive hiatus test. `True` means the two vowels should be split into
+separate syllables. Repeated vowels (`"aa"`) are hiatus; after `r` most vowel
+pairs are hiatus except `"ei"`. Nasal first vowels stay as diphthongs.
+
+```python
+check_for_hiatus("ai", is_end=True)                 # False  (diphthong)
+check_for_hiatus("ai", is_end=False, prev_char="r") # True   (hiatus after r)
+check_for_hiatus("aa")                              # True   (repeated vowel)
+```
+
+## Module constants
+
+`silabificador.syl` also exposes the phonotactic tables the algorithm reads. You
+will rarely import these, but they document the rule set:
+
+| Name | What it holds |
+|---|---|
+| `VOWELS` | every character treated as a vowel (plain, accented, foreign `y`/`w`) |
+| `SEMIVOWEL` | glide-capable letters (`i`, `u`, `y`, `w`) |
+| `INSEPARABLE_DIGRAPHS` | `ch`, `lh`, `nh`, `gu`, `qu` — always one syllable |
+| `SEPARABLE_DIGRAPHS` | clusters split across a boundary (`rr`, `ss`, `ct`, …) |
+| `CONSONANT_DIGRAPHS` | clusters that can start a syllable (`pr`, `bl`, `tr`, …) |
+| `ACUTE`, `CIRCUMFLEX`, `NASAL`, `GRAVE` | the diacritic classes |
+
+## Where next
+
+- [quickstart.md](quickstart.md) — install and first calls
+- [advanced.md](advanced.md) — recipes, batch use, diphthong/hiatus internals

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,96 @@
+# Quickstart — zero to hero
+
+`silabificador` splits a Portuguese word into syllables. One function, pure
+Python, no runtime dependencies. If you can call `str.split`, you already know
+the shape of the API.
+
+## 1. Install
+
+```bash
+pip install git+https://github.com/TigreGotico/silabificador
+```
+
+From a checkout:
+
+```bash
+pip install -e .
+```
+
+Requires Python >= 3.7. Nothing else — the algorithm is hand-crafted rules, no
+models to download.
+
+## 2. The one thing to understand
+
+`syllabify(word)` takes one word and returns a list of syllable strings, in
+order. Accents and digraphs are preserved exactly as written.
+
+```python
+from silabificador import syllabify
+
+print(syllabify("computador"))
+# ['com', 'pu', 'ta', 'dor']
+```
+
+The returned syllables join back into the input (lowercased): `"".join(...)`
+reconstructs the word.
+
+```python
+word = "português"
+syls = syllabify(word)
+print(syls)              # ['por', 'tu', 'guês']
+print("".join(syls))     # 'português'
+print(len(syls))         # 3  -> syllable count
+```
+
+## 3. Real Portuguese, real splits
+
+The rules handle the structures that make Portuguese tricky — consonant
+clusters, diphthongs, hiatus, nasal vowels, and the inseparable digraphs
+(`ch`, `lh`, `nh`, `gu`, `qu`).
+
+```python
+from silabificador import syllabify
+
+syllabify("Brasil")       # ['bra', 'sil']    onset cluster 'br' stays together
+syllabify("filho")        # ['fi', 'lho']     'lh' is inseparable
+syllabify("quando")       # ['quan', 'do']    'qu' digraph, 'u' acts as vowel
+syllabify("água")         # ['á', 'gua']      rising diphthong 'ua'
+syllabify("café")         # ['ca', 'fé']      accent preserved
+syllabify("mãe")          # ['mãe']           nasal diphthong, one syllable
+syllabify("saída")        # ['sa', 'í', 'da'] acute 'í' forces a hiatus
+syllabify("carro")        # ['car', 'ro']     'rr' splits across the boundary
+```
+
+## 4. The class wrapper
+
+If you prefer an object, `Syllabifier` exposes the same call as a method. It
+holds no state — it is a thin handle over `syllabify`.
+
+```python
+from silabificador import Syllabifier
+
+s = Syllabifier()
+print(s.syllabify("caça"))   # ['ca', 'ça']
+```
+
+Use the bare `syllabify` function unless an interface in your code expects an
+object with a `.syllabify` method.
+
+## 5. Counting and joining
+
+Because the output is a plain list, everything you do with lists works:
+
+```python
+from silabificador import syllabify
+
+word = "extraordinário"
+syls = syllabify(word)
+print(syls)                       # ['ex', 'tra', 'or', 'di', 'ná', 'ri', 'o']
+print("number of syllables:", len(syls))
+print("hyphenated:", "-".join(syls))   # ex-tra-or-di-ná-ri-o
+```
+
+## Where next
+
+- [api.md](api.md) — every public symbol, real signatures, return shapes
+- [advanced.md](advanced.md) — digraphs, diphthong vs. hiatus, batch use, gotchas

--- a/examples/01_basic.py
+++ b/examples/01_basic.py
@@ -1,0 +1,23 @@
+"""Example — the core call: split a Portuguese word into syllables.
+
+Run::
+
+    python examples/01_basic.py
+"""
+from silabificador import syllabify
+
+
+def main() -> None:
+    words = ["computador", "Brasil", "português", "casa", "café"]
+    for word in words:
+        syls = syllabify(word)
+        print(f"{word:14} -> {syls}   ({'-'.join(syls)})")
+
+    # The syllables join back into the lowercased input.
+    word = "português"
+    assert "".join(syllabify(word)) == word.lower()
+    print("\njoin reconstructs the word:", "".join(syllabify(word)))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/02_class_wrapper.py
+++ b/examples/02_class_wrapper.py
@@ -1,0 +1,21 @@
+"""Example — the Syllabifier object wrapper.
+
+Run::
+
+    python examples/02_class_wrapper.py
+"""
+from silabificador import Syllabifier, syllabify
+
+
+def main() -> None:
+    s = Syllabifier()
+    for word in ["caça", "filho", "chuva", "vinho"]:
+        print(f"{word:8} -> {s.syllabify(word)}")
+
+    # The object method is equivalent to the bare function.
+    assert s.syllabify("computador") == syllabify("computador")
+    print("\nSyllabifier().syllabify == syllabify:", True)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/03_digraphs.py
+++ b/examples/03_digraphs.py
@@ -1,0 +1,25 @@
+"""Example — inseparable digraphs and onset clusters stay intact.
+
+Run::
+
+    python examples/03_digraphs.py
+"""
+from silabificador import syllabify
+
+
+def main() -> None:
+    print("inseparable digraphs (ch, lh, nh, gu, qu) — never split:")
+    for word in ["chuva", "filho", "vinho", "guerra", "quando"]:
+        print(f"  {word:8} -> {'-'.join(syllabify(word))}")
+
+    print("\nonset clusters (consonant + l/r) — travel together:")
+    for word in ["prato", "flores", "brasil", "globo"]:
+        print(f"  {word:8} -> {'-'.join(syllabify(word))}")
+
+    print("\nclusters that split at the boundary:")
+    for word in ["carro", "pacto", "ritmo"]:
+        print(f"  {word:8} -> {'-'.join(syllabify(word))}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/04_diphthong_hiatus.py
+++ b/examples/04_diphthong_hiatus.py
@@ -1,0 +1,25 @@
+"""Example — diphthong (one syllable) vs. hiatus (two syllables).
+
+Run::
+
+    python examples/04_diphthong_hiatus.py
+"""
+from silabificador import syllabify
+from silabificador.syl import validate_diphthong, check_for_hiatus
+
+
+def main() -> None:
+    print("diphthongs stay in one syllable, hiatus splits:")
+    for word in ["pai", "mãe", "saída", "coordenar", "água"]:
+        print(f"  {word:10} -> {'-'.join(syllabify(word))}")
+
+    print("\ninspecting the vowel-pair rules directly:")
+    print("  validate_diphthong('ai') :", validate_diphthong("ai"))
+    print("  validate_diphthong('ea') :", validate_diphthong("ea"))
+    print("  check_for_hiatus('aa')   :", check_for_hiatus("aa"))
+    print("  check_for_hiatus('ai', prev_char='r') :",
+          check_for_hiatus("ai", is_end=False, prev_char="r"))
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/05_triphthong.py
+++ b/examples/05_triphthong.py
@@ -1,0 +1,22 @@
+"""Example — triphthongs (glide + vowel + glide) in one syllable.
+
+Run::
+
+    python examples/05_triphthong.py
+"""
+from silabificador import syllabify
+from silabificador.syl import validate_triphthong
+
+
+def main() -> None:
+    print("words containing a triphthong:")
+    for word in ["Uruguai", "saguão", "enxaguei"]:
+        print(f"  {word:10} -> {'-'.join(syllabify(word))}")
+
+    print("\nvalidate_triphthong on candidate vowel triples:")
+    for triple in ["uai", "uão", "eau", "iei"]:
+        print(f"  {triple} -> {validate_triphthong(triple)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/06_batch_and_count.py
+++ b/examples/06_batch_and_count.py
@@ -1,0 +1,24 @@
+"""Example — syllabify a list of words and use the count.
+
+Run::
+
+    python examples/06_batch_and_count.py
+"""
+from silabificador import syllabify
+
+
+def main() -> None:
+    sentence = "o computador entende a língua portuguesa"
+    print(f"sentence: {sentence}\n")
+
+    total = 0
+    for word in sentence.split():
+        syls = syllabify(word)
+        total += len(syls)
+        print(f"  {word:12} {len(syls)} syllables  {'-'.join(syls)}")
+
+    print(f"\ntotal syllables in the sentence: {total}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a docs/ directory and runnable examples/ for the public API.

## docs/
- quickstart.md — install, the core idea (`syllabify(word) -> List[str]`), first calls, and the `Syllabifier` wrapper.
- api.md — full signatures and return shapes for `syllabify`, `Syllabifier`, and the `validate_diphthong` / `validate_triphthong` / `check_for_hiatus` predicates, plus the phonotactic constant tables.
- advanced.md — inseparable digraphs, onset clusters vs. splitting clusters, diphthong-vs-hiatus, batch syllabification, syllable counting, and gotchas.

## examples/
- 01_basic.py — core syllabify call and join round-trip.
- 02_class_wrapper.py — the `Syllabifier` object, equivalent to the function.
- 03_digraphs.py — inseparable digraphs and onset clusters.
- 04_diphthong_hiatus.py — diphthong vs. hiatus, including the validator predicates.
- 05_triphthong.py — triphthong handling and `validate_triphthong`.
- 06_batch_and_count.py — syllabify a sentence word by word and count syllables.

All six examples run clean against the shared environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added quickstart guide with installation and usage instructions
  * Added complete API reference documenting all public functions and utilities
  * Added advanced guide covering Portuguese syllabification rules and edge cases
  * Added 6 runnable examples demonstrating basic syllabification, class wrapper usage, digraph handling, diphthong/hiatus behavior, triphthongs, and batch processing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TigreGotico/silabificador/pull/6?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->