### PR TITLE
feat: build the gold from the unified lexicon and score the full set

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,5 +12,5 @@ jobs:
       python_version: '3.11'
       coverage_source: 'silabificador'
       test_path: 'tests/'
-      install_extras: 'test'
+      install_extras: '.[test]'
       min_coverage: 0

--- a/benchmark/__init__.py
+++ b/benchmark/__init__.py
@@ -1,0 +1,7 @@
+"""Benchmark harness for silabificador.
+
+Not part of the installed package. Requires the ``benchmark`` extra:
+
+    uv pip install -e .[benchmark]
+    python -m benchmark.report
+"""

--- a/benchmark/gold.py
+++ b/benchmark/gold.py
@@ -1,0 +1,190 @@
+"""Gold set construction from the unified Portuguese pronunciation lexicon.
+
+The lexicon (``TigreGotico/portuguese-unified-pronunciation-lexicon``) carries a
+``syllables`` column populated from two independent authorities:
+
+* **Infopédia** (Porto Editora dictionary) -- dot-separated, region ``pt-PT``.
+* **Portal da Língua Portuguesa** -- pipe-separated, repeated once per phonetic
+  region. The orthographic split is identical across regions, so it is deduped.
+
+Neither source is taken on faith. Every entry must satisfy *join-integrity*:
+concatenating its syllables must reproduce the headword exactly. Entries that
+fail (a dropped syllable, a hyphen the source silently deletes) are discarded
+rather than repaired, and counted in :attr:`GoldSet.dropped`.
+
+The two sources are then compared word by word:
+
+* **agreement** -- both sources, identical split. This is the primary gold.
+* **infopedia-only** / **portal-only** -- one source, unverifiable.
+* **disagreement** -- both sources, different splits. Excluded from gold and
+  reported, because these encode genuine convention conflicts (morphological
+  prefix boundaries vs onset maximization; etymological hiatus vs diphthong),
+  not transcription noise. Scoring against either answer would be arbitrary.
+"""
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Sequence, Tuple
+
+Split = Tuple[str, ...]
+
+REPO_ID = "TigreGotico/portuguese-unified-pronunciation-lexicon"
+PARQUET = "train.parquet"
+
+#: Fraction of the agreement set reserved as the held-out test split.
+TEST_FRACTION = 0.2
+
+
+def _bucket(word: str) -> float:
+    """Stable [0, 1) hash of a word. Independent of PYTHONHASHSEED and of order."""
+    digest = hashlib.sha1(word.encode("utf-8")).digest()
+    return int.from_bytes(digest[:8], "big") / float(1 << 64)
+
+
+def is_test(word: str) -> bool:
+    """Assign a word to the held-out test split.
+
+    Deterministic and content-addressed: a word lands in the same split no
+    matter how the lexicon is ordered or filtered. Tuning happens on ``dev``;
+    the reported number is ``test``.
+    """
+    return _bucket(word) < TEST_FRACTION
+
+
+@dataclass
+class GoldSet:
+    """Word -> syllable split, for each provenance class."""
+
+    agreement: Dict[str, Split] = field(default_factory=dict)
+    infopedia_only: Dict[str, Split] = field(default_factory=dict)
+    portal_only: Dict[str, Split] = field(default_factory=dict)
+    disagreement: Dict[str, Tuple[Split, Split]] = field(default_factory=dict)
+    dropped: Dict[str, int] = field(default_factory=dict)
+
+    @property
+    def infopedia(self) -> Dict[str, Split]:
+        """Every Infopédia-attested word (agreement set included)."""
+        return {**self.agreement, **self.infopedia_only}
+
+    @property
+    def portal(self) -> Dict[str, Split]:
+        """Every Portal-attested word (agreement set included)."""
+        return {**self.agreement, **self.portal_only}
+
+    def dev(self) -> Dict[str, Split]:
+        return {w: s for w, s in self.agreement.items() if not is_test(w)}
+
+    def test(self) -> Dict[str, Split]:
+        return {w: s for w, s in self.agreement.items() if is_test(w)}
+
+
+def _parse(raw: str) -> Split:
+    """Split a source's ``syllables`` cell into lowercase syllables."""
+    return tuple(p.lower() for p in raw.replace("|", ".").split(".") if p)
+
+
+#: Characters that hold a word together without belonging to any syllable.
+SEPARATORS = "- '’"
+
+
+def fuse(split: Split) -> Split:
+    """Merge syllables across a separator, for comparison only.
+
+    The two are measuring different things and both are right. Infopédia's dots
+    are *hyphenation* points -- places a line may be broken -- and a line may
+    never be broken at a hyphen, so it writes ``a-his.tó.ri.co``, a first token
+    with two nuclei in it. The engine returns *syllables*, one nucleus each, and
+    keeps the hyphen on the syllable it follows: ``a-``, ``his``, ``tó``, ...
+
+    Fusing across separators puts both into the same shape, so the comparison
+    scores the syllabification rather than the notation. It is applied to the
+    gold and the prediction alike.
+    """
+    out = []
+    for syllable in split:
+        if out and out[-1] and out[-1][-1] in SEPARATORS:
+            out[-1] += syllable
+        else:
+            out.append(syllable)
+    return tuple(out)
+
+
+def _collect(rows: Sequence[Tuple[str, str, str]]) -> GoldSet:
+    """Build the gold set from ``(word, syllables, infopedia_url)`` triples."""
+    sources: Dict[str, Dict[str, set]] = {"infopedia": {}, "portal": {}}
+
+    for word, raw, infopedia_url in rows:
+        if not raw:
+            continue
+        key = word.lower()
+        split = _parse(raw)
+        # Infopédia rows carry a dictionary URL; Portal rows do not. The
+        # separator alone is ambiguous for monosyllables, which have neither.
+        source = "infopedia" if infopedia_url else "portal"
+        sources[source].setdefault(key, set()).add(split)
+
+    gold = GoldSet()
+    clean: Dict[str, Dict[str, Split]] = {}
+    for name, entries in sources.items():
+        kept: Dict[str, Split] = {}
+        dropped = 0
+        for word, splits in entries.items():
+            # A word the source cannot even self-consistently split, or whose
+            # syllables do not reconstruct it, is not evidence of anything.
+            if len(splits) != 1:
+                dropped += 1
+                continue
+            (split,) = splits
+            if "".join(split) != word:
+                dropped += 1
+                continue
+            kept[word] = split
+        clean[name] = kept
+        gold.dropped[name] = dropped
+
+    info, portal = clean["infopedia"], clean["portal"]
+    for word, split in info.items():
+        other = portal.get(word)
+        if other is None:
+            gold.infopedia_only[word] = split
+        elif other == split:
+            gold.agreement[word] = split
+        else:
+            gold.disagreement[word] = (split, other)
+    for word, split in portal.items():
+        if word not in info:
+            gold.portal_only[word] = split
+
+    return gold
+
+
+def load(parquet_path: Optional[str] = None) -> GoldSet:
+    """Load the lexicon and build the gold set.
+
+    Downloads the parquet into the shared Hugging Face cache unless a local
+    path is given. No corpus is vendored into this repository.
+    """
+    import pandas as pd
+
+    if parquet_path is None:
+        from huggingface_hub import hf_hub_download
+
+        parquet_path = hf_hub_download(REPO_ID, PARQUET, repo_type="dataset")
+
+    frame = pd.read_parquet(parquet_path, columns=["word", "syllables", "infopedia_url"])
+    return _collect(list(zip(frame.word, frame.syllables, frame.infopedia_url)))
+
+
+def summary(gold: GoldSet) -> List[str]:
+    """Human-readable provenance breakdown."""
+    return [
+        f"agreement (gold)  {len(gold.agreement):>7}   both sources, identical split",
+        f"  dev             {len(gold.dev()):>7}",
+        f"  test (held out) {len(gold.test()):>7}",
+        f"infopedia-only    {len(gold.infopedia_only):>7}   single source, unverified",
+        f"portal-only       {len(gold.portal_only):>7}   single source, unverified",
+        f"disagreement      {len(gold.disagreement):>7}   excluded from gold",
+        f"dropped           {sum(gold.dropped.values()):>7}   failed join-integrity "
+        f"({gold.dropped.get('infopedia', 0)} infopedia, {gold.dropped.get('portal', 0)} portal)",
+    ]

--- a/benchmark/report.py
+++ b/benchmark/report.py
@@ -1,0 +1,120 @@
+"""Full-dataset scoreboard and error taxonomy.
+
+    python -m benchmark.report [--examples N] [--parquet PATH]
+
+Scores the engine on every scoreable word -- no sampling, no caps -- and buckets
+every failure by cause, so residual errors can be described instead of patched.
+"""
+from __future__ import annotations
+
+import argparse
+import collections
+from typing import Dict, List, Tuple
+
+from silabificador import syllabify
+
+from . import gold as goldlib
+from .gold import GoldSet, Split, fuse
+
+VOWELS = "aeiouáéíóúâêîôûàãẽĩõũäëïöüy"
+
+
+def _score(entries: Dict[str, Split]) -> Tuple[int, int, List[Tuple[str, Split, Split]]]:
+    """Exact-match count and every failure, as ``(word, expected, predicted)``."""
+    correct = 0
+    failures = []
+    for word, expected in entries.items():
+        predicted = tuple(syllabify(word))
+        # Compared after fusing across separators: the engine returns syllables,
+        # the dictionaries return hyphenation points. See gold.fuse.
+        if fuse(predicted) == fuse(expected):
+            correct += 1
+        else:
+            failures.append((word, expected, predicted))
+    return correct, len(entries), failures
+
+
+def classify(word: str, expected: Split, predicted: Split) -> str:
+    """Bucket a failure by what the engine got wrong."""
+    if "".join(predicted) != word:
+        # The output does not spell the input. Always a bug, never a
+        # convention difference.
+        return "corruption (output does not reconstruct the word)"
+
+    if len(predicted) > len(expected):
+        return "over-split (predicted hiatus, gold has diphthong)"
+    if len(predicted) < len(expected):
+        return "under-split (predicted diphthong, gold has hiatus)"
+
+    # Same syllable count: a boundary sits in the wrong place. Locate the first
+    # divergent boundary and name the material it falls in.
+    boundary = 0
+    for exp, pred in zip(expected, predicted):
+        if exp != pred:
+            break
+        boundary += len(exp)
+    left = word[max(0, boundary - 2):boundary]
+    right = word[boundary:boundary + 2]
+    around = left + right
+    if any(c not in VOWELS for c in around if c.isalpha()):
+        cluster = "".join(c for c in around if c.isalpha() and c not in VOWELS)
+        return f"boundary in consonant cluster ({cluster or '?'})"
+    return "boundary between vowels"
+
+
+def taxonomy(failures: List[Tuple[str, Split, Split]]) -> collections.Counter:
+    return collections.Counter(classify(w, e, p) for w, e, p in failures)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--parquet", help="local parquet instead of the HF download")
+    parser.add_argument("--examples", type=int, default=5, help="failures to print per bucket")
+    args = parser.parse_args()
+
+    gold = goldlib.load(args.parquet)
+
+    print("PROVENANCE")
+    for line in goldlib.summary(gold):
+        print("  " + line)
+
+    print("\nSCOREBOARD (exact match, full sets, no sampling)")
+    sets = [
+        ("agreement / test (held out)", gold.test()),
+        ("agreement / dev", gold.dev()),
+        ("agreement (all)", gold.agreement),
+        ("infopedia (all)", gold.infopedia),
+        ("portal (all)", gold.portal),
+    ]
+    kept: Dict[str, List[Tuple[str, Split, Split]]] = {}
+    for name, entries in sets:
+        correct, total, failures = _score(entries)
+        kept[name] = failures
+        pct = 100.0 * correct / total if total else 0.0
+        print(f"  {name:<28} {pct:6.2f}%   {correct:>6}/{total:<6}")
+
+    # The taxonomy is printed for the agreement set (the gold the engine is held
+    # to) and for Infopédia (where most of the unverified mass lives, and where
+    # an engine tuned on Portal has never been looked at).
+    for name in ("agreement (all)", "infopedia (all)"):
+        failures = kept[name]
+        print(f"\nERROR TAXONOMY -- {name}: {len(failures)} failures")
+        by_bucket: Dict[str, List] = collections.defaultdict(list)
+        for word, expected, predicted in failures:
+            by_bucket[classify(word, expected, predicted)].append((word, expected, predicted))
+        for bucket, count in taxonomy(failures).most_common():
+            share = 100.0 * count / len(failures) if failures else 0.0
+            print(f"  {count:>5}  ({share:4.1f}%)  {bucket}")
+            for word, expected, predicted in sorted(by_bucket[bucket])[:args.examples]:
+                print(f"           {word:<24} gold={'.'.join(expected):<26} got={'.'.join(predicted)}")
+
+    print("\nROUND-TRIP INVARIANT (every scoreable word)")
+    every = {**gold.infopedia, **gold.portal}
+    broken = [w for w in every if "".join(syllabify(w)) != w]
+    print(f"  {len(every) - len(broken)}/{len(every)} words reconstruct exactly; {len(broken)} corrupted")
+    for word in sorted(broken)[:args.examples]:
+        print(f"    {word:<24} -> {'.'.join(syllabify(word))}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/sample.py
+++ b/benchmark/sample.py
@@ -1,0 +1,41 @@
+"""Regenerate ``tests/gold_sample.json`` -- the committed CI regression gate.
+
+    python -m benchmark.sample
+
+The repository ships no corpus. What it does ship is a small, deterministic draw
+from the *held-out* half of the agreement gold, so the regression test measures
+generalization: none of these words informed a rule.
+"""
+from __future__ import annotations
+
+import json
+import os
+
+from . import gold as goldlib
+
+SIZE = 500
+OUT = os.path.join(os.path.dirname(os.path.dirname(__file__)), "tests", "gold_sample.json")
+
+
+def main() -> None:
+    gold = goldlib.load()
+    held_out = gold.test()
+    # Ordered by the same content hash that defines the split, so the draw is
+    # reproducible from the dataset alone -- no seed to remember, no order to
+    # preserve.
+    words = sorted(held_out, key=goldlib._bucket)[:SIZE]
+
+    payload = {
+        "source": goldlib.REPO_ID,
+        "gold": "agreement (infopedia + portal, identical split, join-integrity checked)",
+        "split": "test (held out)",
+        "entries": [{"word": w, "syllables": list(held_out[w])} for w in words],
+    }
+    with open(OUT, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, ensure_ascii=False, indent=1)
+        handle.write("\n")
+    print(f"wrote {len(words)} entries to {OUT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
 
 [project.optional-dependencies]
 test = ["pytest"]
+benchmark = ["pandas", "pyarrow", "huggingface_hub"]
 
 [project.urls]
 Homepage = "https://github.com/TigreGotico/silabificador"

--- a/tests/gold_sample.json
+++ b/tests/gold_sample.json
@@ -1,4575 +1,4403 @@
 {
-"region": "lbx",
-"entries": [
-{
-"word": "ocupado",
-"syllables": [
-"o",
-"cu",
-"pa",
-"do"
-]
-},
-{
-"word": "balado",
-"syllables": [
-"ba",
-"la",
-"do"
-]
-},
-{
-"word": "afuniladamente",
-"syllables": [
-"a",
-"fu",
-"ni",
-"la",
-"da",
-"men",
-"te"
-]
-},
-{
-"word": "ramboia",
-"syllables": [
-"ram",
-"boi",
-"a"
-]
-},
-{
-"word": "descambar",
-"syllables": [
-"des",
-"cam",
-"bar"
-]
-},
-{
-"word": "cruzado",
-"syllables": [
-"cru",
-"za",
-"do"
-]
-},
-{
-"word": "contrabando",
-"syllables": [
-"con",
-"tra",
-"ban",
-"do"
-]
-},
-{
-"word": "brandir",
-"syllables": [
-"bran",
-"dir"
-]
-},
-{
-"word": "quimioterápico",
-"syllables": [
-"qui",
-"mi",
-"o",
-"te",
-"rá",
-"pi",
-"co"
-]
-},
-{
-"word": "autoria",
-"syllables": [
-"au",
-"to",
-"ri",
-"a"
-]
-},
-{
-"word": "perniciosidade",
-"syllables": [
-"per",
-"ni",
-"ci",
-"o",
-"si",
-"da",
-"de"
-]
-},
-{
-"word": "rafa",
-"syllables": [
-"ra",
-"fa"
-]
-},
-{
-"word": "tremoceiro",
-"syllables": [
-"tre",
-"mo",
-"cei",
-"ro"
-]
-},
-{
-"word": "legislado",
-"syllables": [
-"le",
-"gis",
-"la",
-"do"
-]
-},
-{
-"word": "artroscópio",
-"syllables": [
-"ar",
-"tros",
-"có",
-"pi",
-"o"
-]
-},
-{
-"word": "mestrado",
-"syllables": [
-"mes",
-"tra",
-"do"
-]
-},
-{
-"word": "fluorídrico",
-"syllables": [
-"flu",
-"o",
-"rí",
-"dri",
-"co"
-]
-},
-{
-"word": "albina",
-"syllables": [
-"al",
-"bi",
-"na"
-]
-},
-{
-"word": "ajeitadamente",
-"syllables": [
-"a",
-"jei",
-"ta",
-"da",
-"men",
-"te"
-]
-},
-{
-"word": "atenuador",
-"syllables": [
-"a",
-"te",
-"nu",
-"a",
-"dor"
-]
-},
-{
-"word": "consistório",
-"syllables": [
-"con",
-"sis",
-"tó",
-"ri",
-"o"
-]
-},
-{
-"word": "coreográfico",
-"syllables": [
-"co",
-"re",
-"o",
-"grá",
-"fi",
-"co"
-]
-},
-{
-"word": "inflacionista",
-"syllables": [
-"in",
-"fla",
-"ci",
-"o",
-"nis",
-"ta"
-]
-},
-{
-"word": "moda",
-"syllables": [
-"mo",
-"da"
-]
-},
-{
-"word": "agostinha",
-"syllables": [
-"a",
-"gos",
-"ti",
-"nha"
-]
-},
-{
-"word": "léxico",
-"syllables": [
-"lé",
-"xi",
-"co"
-]
-},
-{
-"word": "coincinerar",
-"syllables": [
-"co",
-"in",
-"ci",
-"ne",
-"rar"
-]
-},
-{
-"word": "propiciar",
-"syllables": [
-"pro",
-"pi",
-"ci",
-"ar"
-]
-},
-{
-"word": "ouvinte",
-"syllables": [
-"ou",
-"vin",
-"te"
-]
-},
-{
-"word": "precaução",
-"syllables": [
-"pre",
-"cau",
-"ção"
-]
-},
-{
-"word": "ledor",
-"syllables": [
-"le",
-"dor"
-]
-},
-{
-"word": "fissural",
-"syllables": [
-"fis",
-"su",
-"ral"
-]
-},
-{
-"word": "consumidor",
-"syllables": [
-"con",
-"su",
-"mi",
-"dor"
-]
-},
-{
-"word": "geórgica",
-"syllables": [
-"ge",
-"ór",
-"gi",
-"ca"
-]
-},
-{
-"word": "mergulhadora",
-"syllables": [
-"mer",
-"gu",
-"lha",
-"do",
-"ra"
-]
-},
-{
-"word": "descompaginar",
-"syllables": [
-"des",
-"com",
-"pa",
-"gi",
-"nar"
-]
-},
-{
-"word": "saurópode",
-"syllables": [
-"sau",
-"ró",
-"po",
-"de"
-]
-},
-{
-"word": "telegrafista",
-"syllables": [
-"te",
-"le",
-"gra",
-"fis",
-"ta"
-]
-},
-{
-"word": "abstencionista",
-"syllables": [
-"abs",
-"ten",
-"ci",
-"o",
-"nis",
-"ta"
-]
-},
-{
-"word": "reduzidamente",
-"syllables": [
-"re",
-"du",
-"zi",
-"da",
-"men",
-"te"
-]
-},
-{
-"word": "sanear",
-"syllables": [
-"sa",
-"ne",
-"ar"
-]
-},
-{
-"word": "cantonal",
-"syllables": [
-"can",
-"to",
-"nal"
-]
-},
-{
-"word": "possivelmente",
-"syllables": [
-"pos",
-"si",
-"vel",
-"men",
-"te"
-]
-},
-{
-"word": "fogareiro",
-"syllables": [
-"fo",
-"ga",
-"rei",
-"ro"
-]
-},
-{
-"word": "elitista",
-"syllables": [
-"e",
-"li",
-"tis",
-"ta"
-]
-},
-{
-"word": "descolonizar",
-"syllables": [
-"des",
-"co",
-"lo",
-"ni",
-"zar"
-]
-},
-{
-"word": "camioneta",
-"syllables": [
-"ca",
-"mi",
-"o",
-"ne",
-"ta"
-]
-},
-{
-"word": "confundido",
-"syllables": [
-"con",
-"fun",
-"di",
-"do"
-]
-},
-{
-"word": "refrigerante",
-"syllables": [
-"re",
-"fri",
-"ge",
-"ran",
-"te"
-]
-},
-{
-"word": "egrégio",
-"syllables": [
-"e",
-"gré",
-"gi",
-"o"
-]
-},
-{
-"word": "autopolinização",
-"syllables": [
-"au",
-"to",
-"po",
-"li",
-"ni",
-"za",
-"ção"
-]
-},
-{
-"word": "atalhada",
-"syllables": [
-"a",
-"ta",
-"lha",
-"da"
-]
-},
-{
-"word": "esquartejado",
-"syllables": [
-"es",
-"quar",
-"te",
-"ja",
-"do"
-]
-},
-{
-"word": "atropeladamente",
-"syllables": [
-"a",
-"tro",
-"pe",
-"la",
-"da",
-"men",
-"te"
-]
-},
-{
-"word": "entreabrir",
-"syllables": [
-"en",
-"tre",
-"a",
-"brir"
-]
-},
-{
-"word": "submersão",
-"syllables": [
-"sub",
-"mer",
-"são"
-]
-},
-{
-"word": "emirado",
-"syllables": [
-"e",
-"mi",
-"ra",
-"do"
-]
-},
-{
-"word": "moldado",
-"syllables": [
-"mol",
-"da",
-"do"
-]
-},
-{
-"word": "desacamaradar",
-"syllables": [
-"de",
-"sa",
-"ca",
-"ma",
-"ra",
-"dar"
-]
-},
-{
-"word": "sapador-bombeiro",
-"syllables": [
-"sa",
-"pa",
-"dor",
-"bom",
-"bei",
-"ro"
-]
-},
-{
-"word": "amargurado",
-"syllables": [
-"a",
-"mar",
-"gu",
-"ra",
-"do"
-]
-},
-{
-"word": "pária",
-"syllables": [
-"pá",
-"ri",
-"a"
-]
-},
-{
-"word": "guardense",
-"syllables": [
-"guar",
-"den",
-"se"
-]
-},
-{
-"word": "jurídico-constitucional",
-"syllables": [
-"ju",
-"rí",
-"di",
-"co",
-"cons",
-"ti",
-"tu",
-"ci",
-"o",
-"nal"
-]
-},
-{
-"word": "betonagem",
-"syllables": [
-"be",
-"to",
-"na",
-"gem"
-]
-},
-{
-"word": "viandante",
-"syllables": [
-"vi",
-"an",
-"dan",
-"te"
-]
-},
-{
-"word": "espirrador",
-"syllables": [
-"es",
-"pir",
-"ra",
-"dor"
-]
-},
-{
-"word": "arlequim",
-"syllables": [
-"ar",
-"le",
-"quim"
-]
-},
-{
-"word": "linguado",
-"syllables": [
-"lin",
-"gua",
-"do"
-]
-},
-{
-"word": "desgraceira",
-"syllables": [
-"des",
-"gra",
-"cei",
-"ra"
-]
-},
-{
-"word": "sinónimo",
-"syllables": [
-"si",
-"nó",
-"ni",
-"mo"
-]
-},
-{
-"word": "nigerino",
-"syllables": [
-"ni",
-"ge",
-"ri",
-"no"
-]
-},
-{
-"word": "mísula",
-"syllables": [
-"mí",
-"su",
-"la"
-]
-},
-{
-"word": "tradicionalista",
-"syllables": [
-"tra",
-"di",
-"ci",
-"o",
-"na",
-"lis",
-"ta"
-]
-},
-{
-"word": "taberna",
-"syllables": [
-"ta",
-"ber",
-"na"
-]
-},
-{
-"word": "enxerga",
-"syllables": [
-"en",
-"xer",
-"ga"
-]
-},
-{
-"word": "marista",
-"syllables": [
-"ma",
-"ris",
-"ta"
-]
-},
-{
-"word": "clarificador",
-"syllables": [
-"cla",
-"ri",
-"fi",
-"ca",
-"dor"
-]
-},
-{
-"word": "prelada",
-"syllables": [
-"pre",
-"la",
-"da"
-]
-},
-{
-"word": "apavorante",
-"syllables": [
-"a",
-"pa",
-"vo",
-"ran",
-"te"
-]
-},
-{
-"word": "amigo",
-"syllables": [
-"a",
-"mi",
-"go"
-]
-},
-{
-"word": "parolo",
-"syllables": [
-"pa",
-"ro",
-"lo"
-]
-},
-{
-"word": "contravertente",
-"syllables": [
-"con",
-"tra",
-"ver",
-"ten",
-"te"
-]
-},
-{
-"word": "rendado",
-"syllables": [
-"ren",
-"da",
-"do"
-]
-},
-{
-"word": "desentulho",
-"syllables": [
-"de",
-"sen",
-"tu",
-"lho"
-]
-},
-{
-"word": "arpar",
-"syllables": [
-"ar",
-"par"
-]
-},
-{
-"word": "supernumerário",
-"syllables": [
-"su",
-"per",
-"nu",
-"me",
-"rá",
-"ri",
-"o"
-]
-},
-{
-"word": "corgo",
-"syllables": [
-"cor",
-"go"
-]
-},
-{
-"word": "tasca",
-"syllables": [
-"tas",
-"ca"
-]
-},
-{
-"word": "autogenético",
-"syllables": [
-"au",
-"to",
-"ge",
-"né",
-"ti",
-"co"
-]
-},
-{
-"word": "esquematicamente",
-"syllables": [
-"es",
-"que",
-"ma",
-"ti",
-"ca",
-"men",
-"te"
-]
-},
-{
-"word": "descolorir",
-"syllables": [
-"des",
-"co",
-"lo",
-"rir"
-]
-},
-{
-"word": "gotejar",
-"syllables": [
-"go",
-"te",
-"jar"
-]
-},
-{
-"word": "obituário",
-"syllables": [
-"o",
-"bi",
-"tu",
-"á",
-"ri",
-"o"
-]
-},
-{
-"word": "sobrepratear",
-"syllables": [
-"so",
-"bre",
-"pra",
-"te",
-"ar"
-]
-},
-{
-"word": "ermo",
-"syllables": [
-"er",
-"mo"
-]
-},
-{
-"word": "caranguejo",
-"syllables": [
-"ca",
-"ran",
-"gue",
-"jo"
-]
-},
-{
-"word": "escovagem",
-"syllables": [
-"es",
-"co",
-"va",
-"gem"
-]
-},
-{
-"word": "enjoado",
-"syllables": [
-"en",
-"jo",
-"a",
-"do"
-]
-},
-{
-"word": "comunidade",
-"syllables": [
-"co",
-"mu",
-"ni",
-"da",
-"de"
-]
-},
-{
-"word": "pelaria",
-"syllables": [
-"pe",
-"la",
-"ri",
-"a"
-]
-},
-{
-"word": "desagregador",
-"syllables": [
-"de",
-"sa",
-"gre",
-"ga",
-"dor"
-]
-},
-{
-"word": "precipitado",
-"syllables": [
-"pre",
-"ci",
-"pi",
-"ta",
-"do"
-]
-},
-{
-"word": "zomba",
-"syllables": [
-"zom",
-"ba"
-]
-},
-{
-"word": "pinguim",
-"syllables": [
-"pin",
-"guim"
-]
-},
-{
-"word": "ortónimo",
-"syllables": [
-"or",
-"tó",
-"ni",
-"mo"
-]
-},
-{
-"word": "apodar",
-"syllables": [
-"a",
-"po",
-"dar"
-]
-},
-{
-"word": "mormente",
-"syllables": [
-"mor",
-"men",
-"te"
-]
-},
-{
-"word": "nórdico",
-"syllables": [
-"nór",
-"di",
-"co"
-]
-},
-{
-"word": "cataclísmico",
-"syllables": [
-"ca",
-"ta",
-"clís",
-"mi",
-"co"
-]
-},
-{
-"word": "joguetar",
-"syllables": [
-"jo",
-"gue",
-"tar"
-]
-},
-{
-"word": "purpurino",
-"syllables": [
-"pur",
-"pu",
-"ri",
-"no"
-]
-},
-{
-"word": "crustáceo",
-"syllables": [
-"crus",
-"tá",
-"ce",
-"o"
-]
-},
-{
-"word": "carbônico",
-"syllables": [
-"car",
-"bô",
-"ni",
-"co"
-]
-},
-{
-"word": "haco",
-"syllables": [
-"ha",
-"co"
-]
-},
-{
-"word": "espumadeira",
-"syllables": [
-"es",
-"pu",
-"ma",
-"dei",
-"ra"
-]
-},
-{
-"word": "desapor",
-"syllables": [
-"de",
-"sa",
-"por"
-]
-},
-{
-"word": "vinagreta",
-"syllables": [
-"vi",
-"na",
-"gre",
-"ta"
-]
-},
-{
-"word": "ofensiva",
-"syllables": [
-"o",
-"fen",
-"si",
-"va"
-]
-},
-{
-"word": "platinado",
-"syllables": [
-"pla",
-"ti",
-"na",
-"do"
-]
-},
-{
-"word": "loro",
-"syllables": [
-"lo",
-"ro"
-]
-},
-{
-"word": "constituinte",
-"syllables": [
-"cons",
-"ti",
-"tu",
-"in",
-"te"
-]
-},
-{
-"word": "piparotar",
-"syllables": [
-"pi",
-"pa",
-"ro",
-"tar"
-]
-},
-{
-"word": "ditenda",
-"syllables": [
-"di",
-"ten",
-"da"
-]
-},
-{
-"word": "suazi",
-"syllables": [
-"su",
-"a",
-"zi"
-]
-},
-{
-"word": "relampejar",
-"syllables": [
-"re",
-"lam",
-"pe",
-"jar"
-]
-},
-{
-"word": "repisador",
-"syllables": [
-"re",
-"pi",
-"sa",
-"dor"
-]
-},
-{
-"word": "antepagar",
-"syllables": [
-"an",
-"te",
-"pa",
-"gar"
-]
-},
-{
-"word": "convencido",
-"syllables": [
-"con",
-"ven",
-"ci",
-"do"
-]
-},
-{
-"word": "serralhar",
-"syllables": [
-"ser",
-"ra",
-"lhar"
-]
-},
-{
-"word": "alcalinoterapia",
-"syllables": [
-"al",
-"ca",
-"li",
-"no",
-"te",
-"ra",
-"pi",
-"a"
-]
-},
-{
-"word": "samarra",
-"syllables": [
-"sa",
-"mar",
-"ra"
-]
-},
-{
-"word": "dielétrico",
-"syllables": [
-"di",
-"e",
-"lé",
-"tri",
-"co"
-]
-},
-{
-"word": "extrapolação",
-"syllables": [
-"ex",
-"tra",
-"po",
-"la",
-"ção"
-]
-},
-{
-"word": "desalforjar",
-"syllables": [
-"de",
-"sal",
-"for",
-"jar"
-]
-},
-{
-"word": "antiácido",
-"syllables": [
-"an",
-"ti",
-"á",
-"ci",
-"do"
-]
-},
-{
-"word": "concertista",
-"syllables": [
-"con",
-"cer",
-"tis",
-"ta"
-]
-},
-{
-"word": "valsa",
-"syllables": [
-"val",
-"sa"
-]
-},
-{
-"word": "mal-agradecido",
-"syllables": [
-"mal",
-"a",
-"gra",
-"de",
-"ci",
-"do"
-]
-},
-{
-"word": "tia-avó",
-"syllables": [
-"ti",
-"a",
-"a",
-"vó"
-]
-},
-{
-"word": "protegido",
-"syllables": [
-"pro",
-"te",
-"gi",
-"do"
-]
-},
-{
-"word": "diarístico",
-"syllables": [
-"di",
-"a",
-"rís",
-"ti",
-"co"
-]
-},
-{
-"word": "condensação",
-"syllables": [
-"con",
-"den",
-"sa",
-"ção"
-]
-},
-{
-"word": "panaça",
-"syllables": [
-"pa",
-"na",
-"ça"
-]
-},
-{
-"word": "indisfarçável",
-"syllables": [
-"in",
-"dis",
-"far",
-"çá",
-"vel"
-]
-},
-{
-"word": "executório",
-"syllables": [
-"e",
-"xe",
-"cu",
-"tó",
-"ri",
-"o"
-]
-},
-{
-"word": "toureiro",
-"syllables": [
-"tou",
-"rei",
-"ro"
-]
-},
-{
-"word": "varonilmente",
-"syllables": [
-"va",
-"ro",
-"nil",
-"men",
-"te"
-]
-},
-{
-"word": "onagro",
-"syllables": [
-"o",
-"na",
-"gro"
-]
-},
-{
-"word": "guapo",
-"syllables": [
-"gua",
-"po"
-]
-},
-{
-"word": "brâmane",
-"syllables": [
-"brâ",
-"ma",
-"ne"
-]
-},
-{
-"word": "desaclimatado",
-"syllables": [
-"de",
-"sa",
-"cli",
-"ma",
-"ta",
-"do"
-]
-},
-{
-"word": "branqueador",
-"syllables": [
-"bran",
-"que",
-"a",
-"dor"
-]
-},
-{
-"word": "cumplicidade",
-"syllables": [
-"cum",
-"pli",
-"ci",
-"da",
-"de"
-]
-},
-{
-"word": "reacionário",
-"syllables": [
-"re",
-"a",
-"ci",
-"o",
-"ná",
-"ri",
-"o"
-]
-},
-{
-"word": "líbio",
-"syllables": [
-"lí",
-"bi",
-"o"
-]
-},
-{
-"word": "lagareiro",
-"syllables": [
-"la",
-"ga",
-"rei",
-"ro"
-]
-},
-{
-"word": "depurador",
-"syllables": [
-"de",
-"pu",
-"ra",
-"dor"
-]
-},
-{
-"word": "reassunção",
-"syllables": [
-"re",
-"as",
-"sun",
-"ção"
-]
-},
-{
-"word": "medroso",
-"syllables": [
-"me",
-"dro",
-"so"
-]
-},
-{
-"word": "fotossensibilidade",
-"syllables": [
-"fo",
-"tos",
-"sen",
-"si",
-"bi",
-"li",
-"da",
-"de"
-]
-},
-{
-"word": "triunfador",
-"syllables": [
-"tri",
-"un",
-"fa",
-"dor"
-]
-},
-{
-"word": "mediante",
-"syllables": [
-"me",
-"di",
-"an",
-"te"
-]
-},
-{
-"word": "extenuado",
-"syllables": [
-"ex",
-"te",
-"nu",
-"a",
-"do"
-]
-},
-{
-"word": "enxundiosamente",
-"syllables": [
-"en",
-"xun",
-"di",
-"o",
-"sa",
-"men",
-"te"
-]
-},
-{
-"word": "constatável",
-"syllables": [
-"cons",
-"ta",
-"tá",
-"vel"
-]
-},
-{
-"word": "botsuana",
-"syllables": [
-"bot",
-"su",
-"a",
-"na"
-]
-},
-{
-"word": "injustificadamente",
-"syllables": [
-"in",
-"jus",
-"ti",
-"fi",
-"ca",
-"da",
-"men",
-"te"
-]
-},
-{
-"word": "inconspícuo",
-"syllables": [
-"in",
-"cons",
-"pí",
-"cu",
-"o"
-]
-},
-{
-"word": "associativista",
-"syllables": [
-"as",
-"so",
-"ci",
-"a",
-"ti",
-"vis",
-"ta"
-]
-},
-{
-"word": "recrudescido",
-"syllables": [
-"re",
-"cru",
-"des",
-"ci",
-"do"
-]
-},
-{
-"word": "amortecedor",
-"syllables": [
-"a",
-"mor",
-"te",
-"ce",
-"dor"
-]
-},
-{
-"word": "sónico",
-"syllables": [
-"só",
-"ni",
-"co"
-]
-},
-{
-"word": "badalo",
-"syllables": [
-"ba",
-"da",
-"lo"
-]
-},
-{
-"word": "californiano",
-"syllables": [
-"ca",
-"li",
-"for",
-"ni",
-"a",
-"no"
-]
-},
-{
-"word": "neuropsiquiátrico",
-"syllables": [
-"neu",
-"rop",
-"si",
-"qui",
-"á",
-"tri",
-"co"
-]
-},
-{
-"word": "canário",
-"syllables": [
-"ca",
-"ná",
-"ri",
-"o"
-]
-},
-{
-"word": "ritmo",
-"syllables": [
-"rit",
-"mo"
-]
-},
-{
-"word": "petróleo",
-"syllables": [
-"pe",
-"tró",
-"le",
-"o"
-]
-},
-{
-"word": "flã",
-"syllables": [
-"flã"
-]
-},
-{
-"word": "milhos",
-"syllables": [
-"mi",
-"lhos"
-]
-},
-{
-"word": "antiparalítico",
-"syllables": [
-"an",
-"ti",
-"pa",
-"ra",
-"lí",
-"ti",
-"co"
-]
-},
-{
-"word": "estimativo",
-"syllables": [
-"es",
-"ti",
-"ma",
-"ti",
-"vo"
-]
-},
-{
-"word": "estafe",
-"syllables": [
-"es",
-"ta",
-"fe"
-]
-},
-{
-"word": "milagreira",
-"syllables": [
-"mi",
-"la",
-"grei",
-"ra"
-]
-},
-{
-"word": "hiperalimentação",
-"syllables": [
-"hi",
-"pe",
-"ra",
-"li",
-"men",
-"ta",
-"ção"
-]
-},
-{
-"word": "irretroatividade",
-"syllables": [
-"ir",
-"re",
-"tro",
-"a",
-"ti",
-"vi",
-"da",
-"de"
-]
-},
-{
-"word": "damo",
-"syllables": [
-"da",
-"mo"
-]
-},
-{
-"word": "lisonjeador",
-"syllables": [
-"li",
-"son",
-"je",
-"a",
-"dor"
-]
-},
-{
-"word": "síntese",
-"syllables": [
-"sín",
-"te",
-"se"
-]
-},
-{
-"word": "acne",
-"syllables": [
-"ac",
-"ne"
-]
-},
-{
-"word": "petrificar",
-"syllables": [
-"pe",
-"tri",
-"fi",
-"car"
-]
-},
-{
-"word": "provo",
-"syllables": [
-"pro",
-"vo"
-]
-},
-{
-"word": "banquete",
-"syllables": [
-"ban",
-"que",
-"te"
-]
-},
-{
-"word": "picotar",
-"syllables": [
-"pi",
-"co",
-"tar"
-]
-},
-{
-"word": "toutiço",
-"syllables": [
-"tou",
-"ti",
-"ço"
-]
-},
-{
-"word": "jóquei",
-"syllables": [
-"jó",
-"quei"
-]
-},
-{
-"word": "recentemente",
-"syllables": [
-"re",
-"cen",
-"te",
-"men",
-"te"
-]
-},
-{
-"word": "desagradecido",
-"syllables": [
-"de",
-"sa",
-"gra",
-"de",
-"ci",
-"do"
-]
-},
-{
-"word": "relativista",
-"syllables": [
-"re",
-"la",
-"ti",
-"vis",
-"ta"
-]
-},
-{
-"word": "oitavário",
-"syllables": [
-"oi",
-"ta",
-"vá",
-"ri",
-"o"
-]
-},
-{
-"word": "elipticamente",
-"syllables": [
-"e",
-"lip",
-"ti",
-"ca",
-"men",
-"te"
-]
-},
-{
-"word": "balançar",
-"syllables": [
-"ba",
-"lan",
-"çar"
-]
-},
-{
-"word": "desiderato",
-"syllables": [
-"de",
-"si",
-"de",
-"ra",
-"to"
-]
-},
-{
-"word": "fumaça",
-"syllables": [
-"fu",
-"ma",
-"ça"
-]
-},
-{
-"word": "cangalhada",
-"syllables": [
-"can",
-"ga",
-"lha",
-"da"
-]
-},
-{
-"word": "governança",
-"syllables": [
-"go",
-"ver",
-"nan",
-"ça"
-]
-},
-{
-"word": "abismal",
-"syllables": [
-"a",
-"bis",
-"mal"
-]
-},
-{
-"word": "pré-definido",
-"syllables": [
-"pré",
-"de",
-"fi",
-"ni",
-"do"
-]
-},
-{
-"word": "teu",
-"syllables": [
-"teu"
-]
-},
-{
-"word": "proustiano",
-"syllables": [
-"prous",
-"ti",
-"a",
-"no"
-]
-},
-{
-"word": "derretimento",
-"syllables": [
-"der",
-"re",
-"ti",
-"men",
-"to"
-]
-},
-{
-"word": "indormir",
-"syllables": [
-"in",
-"dor",
-"mir"
-]
-},
-{
-"word": "refletir",
-"syllables": [
-"re",
-"fle",
-"tir"
-]
-},
-{
-"word": "cerefólio",
-"syllables": [
-"ce",
-"re",
-"fó",
-"li",
-"o"
-]
-},
-{
-"word": "inglesar",
-"syllables": [
-"in",
-"gle",
-"sar"
-]
-},
-{
-"word": "valida",
-"syllables": [
-"va",
-"li",
-"da"
-]
-},
-{
-"word": "azarado",
-"syllables": [
-"a",
-"za",
-"ra",
-"do"
-]
-},
-{
-"word": "telheiro",
-"syllables": [
-"te",
-"lhei",
-"ro"
-]
-},
-{
-"word": "neoidealismo",
-"syllables": [
-"ne",
-"oi",
-"de",
-"a",
-"lis",
-"mo"
-]
-},
-{
-"word": "desmobilizado",
-"syllables": [
-"des",
-"mo",
-"bi",
-"li",
-"za",
-"do"
-]
-},
-{
-"word": "sorumbaticamente",
-"syllables": [
-"so",
-"rum",
-"ba",
-"ti",
-"ca",
-"men",
-"te"
-]
-},
-{
-"word": "octogenária",
-"syllables": [
-"oc",
-"to",
-"ge",
-"ná",
-"ri",
-"a"
-]
-},
-{
-"word": "inglesado",
-"syllables": [
-"in",
-"gle",
-"sa",
-"do"
-]
-},
-{
-"word": "morgado",
-"syllables": [
-"mor",
-"ga",
-"do"
-]
-},
-{
-"word": "coinquilino",
-"syllables": [
-"co",
-"in",
-"qui",
-"li",
-"no"
-]
-},
-{
-"word": "esmeralda",
-"syllables": [
-"es",
-"me",
-"ral",
-"da"
-]
-},
-{
-"word": "refolhar",
-"syllables": [
-"re",
-"fo",
-"lhar"
-]
-},
-{
-"word": "caprichoso",
-"syllables": [
-"ca",
-"pri",
-"cho",
-"so"
-]
-},
-{
-"word": "laicização",
-"syllables": [
-"lai",
-"ci",
-"za",
-"ção"
-]
-},
-{
-"word": "repuxado",
-"syllables": [
-"re",
-"pu",
-"xa",
-"do"
-]
-},
-{
-"word": "viação",
-"syllables": [
-"vi",
-"a",
-"ção"
-]
-},
-{
-"word": "isquemia",
-"syllables": [
-"is",
-"que",
-"mi",
-"a"
-]
-},
-{
-"word": "veraneio",
-"syllables": [
-"ve",
-"ra",
-"nei",
-"o"
-]
-},
-{
-"word": "abafar",
-"syllables": [
-"a",
-"ba",
-"far"
-]
-},
-{
-"word": "minuto",
-"syllables": [
-"mi",
-"nu",
-"to"
-]
-},
-{
-"word": "dita",
-"syllables": [
-"di",
-"ta"
-]
-},
-{
-"word": "inassiduidade",
-"syllables": [
-"i",
-"nas",
-"si",
-"du",
-"i",
-"da",
-"de"
-]
-},
-{
-"word": "adventício",
-"syllables": [
-"ad",
-"ven",
-"tí",
-"ci",
-"o"
-]
-},
-{
-"word": "balcânico",
-"syllables": [
-"bal",
-"câ",
-"ni",
-"co"
-]
-},
-{
-"word": "vitamínico",
-"syllables": [
-"vi",
-"ta",
-"mí",
-"ni",
-"co"
-]
-},
-{
-"word": "epistolografia",
-"syllables": [
-"e",
-"pis",
-"to",
-"lo",
-"gra",
-"fi",
-"a"
-]
-},
-{
-"word": "titanicamente",
-"syllables": [
-"ti",
-"ta",
-"ni",
-"ca",
-"men",
-"te"
-]
-},
-{
-"word": "sobreaquecer",
-"syllables": [
-"so",
-"bre",
-"a",
-"que",
-"cer"
-]
-},
-{
-"word": "santeiro",
-"syllables": [
-"san",
-"tei",
-"ro"
-]
-},
-{
-"word": "desterrado",
-"syllables": [
-"des",
-"ter",
-"ra",
-"do"
-]
-},
-{
-"word": "couve",
-"syllables": [
-"cou",
-"ve"
-]
-},
-{
-"word": "antianglicano",
-"syllables": [
-"an",
-"ti",
-"an",
-"gli",
-"ca",
-"no"
-]
-},
-{
-"word": "creditório",
-"syllables": [
-"cre",
-"di",
-"tó",
-"ri",
-"o"
-]
-},
-{
-"word": "tiracolo",
-"syllables": [
-"ti",
-"ra",
-"co",
-"lo"
-]
-},
-{
-"word": "mal-humorado",
-"syllables": [
-"mal",
-"hu",
-"mo",
-"ra",
-"do"
-]
-},
-{
-"word": "aritmética",
-"syllables": [
-"a",
-"rit",
-"mé",
-"ti",
-"ca"
-]
-},
-{
-"word": "arrudense",
-"syllables": [
-"ar",
-"ru",
-"den",
-"se"
-]
-},
-{
-"word": "púrpura",
-"syllables": [
-"púr",
-"pu",
-"ra"
-]
-},
-{
-"word": "impulsionador",
-"syllables": [
-"im",
-"pul",
-"si",
-"o",
-"na",
-"dor"
-]
-},
-{
-"word": "semigola",
-"syllables": [
-"se",
-"mi",
-"go",
-"la"
-]
-},
-{
-"word": "apartado",
-"syllables": [
-"a",
-"par",
-"ta",
-"do"
-]
-},
-{
-"word": "reexpedidor",
-"syllables": [
-"re",
-"ex",
-"pe",
-"di",
-"dor"
-]
-},
-{
-"word": "jarreteira",
-"syllables": [
-"jar",
-"re",
-"tei",
-"ra"
-]
-},
-{
-"word": "reguenga",
-"syllables": [
-"re",
-"guen",
-"ga"
-]
-},
-{
-"word": "bicameralismo",
-"syllables": [
-"bi",
-"ca",
-"me",
-"ra",
-"lis",
-"mo"
-]
-},
-{
-"word": "bilinguismo",
-"syllables": [
-"bi",
-"lin",
-"guis",
-"mo"
-]
-},
-{
-"word": "paraíso",
-"syllables": [
-"pa",
-"ra",
-"í",
-"so"
-]
-},
-{
-"word": "hussita",
-"syllables": [
-"hus",
-"si",
-"ta"
-]
-},
-{
-"word": "libélula",
-"syllables": [
-"li",
-"bé",
-"lu",
-"la"
-]
-},
-{
-"word": "carioca",
-"syllables": [
-"ca",
-"ri",
-"o",
-"ca"
-]
-},
-{
-"word": "desacompanhar",
-"syllables": [
-"de",
-"sa",
-"com",
-"pa",
-"nhar"
-]
-},
-{
-"word": "ironista",
-"syllables": [
-"i",
-"ro",
-"nis",
-"ta"
-]
-},
-{
-"word": "tenuemente",
-"syllables": [
-"te",
-"nu",
-"e",
-"men",
-"te"
-]
-},
-{
-"word": "monovolume",
-"syllables": [
-"mo",
-"no",
-"vo",
-"lu",
-"me"
-]
-},
-{
-"word": "foleirada",
-"syllables": [
-"fo",
-"lei",
-"ra",
-"da"
-]
-},
-{
-"word": "concordância",
-"syllables": [
-"con",
-"cor",
-"dân",
-"ci",
-"a"
-]
-},
-{
-"word": "vitalidade",
-"syllables": [
-"vi",
-"ta",
-"li",
-"da",
-"de"
-]
-},
-{
-"word": "laicado",
-"syllables": [
-"lai",
-"ca",
-"do"
-]
-},
-{
-"word": "recovo",
-"syllables": [
-"re",
-"co",
-"vo"
-]
-},
-{
-"word": "pânico",
-"syllables": [
-"pâ",
-"ni",
-"co"
-]
-},
-{
-"word": "pneumologista",
-"syllables": [
-"pneu",
-"mo",
-"lo",
-"gis",
-"ta"
-]
-},
-{
-"word": "colina",
-"syllables": [
-"co",
-"li",
-"na"
-]
-},
-{
-"word": "profiláctico",
-"syllables": [
-"pro",
-"fi",
-"lác",
-"ti",
-"co"
-]
-},
-{
-"word": "deturpador",
-"syllables": [
-"de",
-"tur",
-"pa",
-"dor"
-]
-},
-{
-"word": "expulsar",
-"syllables": [
-"ex",
-"pul",
-"sar"
-]
-},
-{
-"word": "penha",
-"syllables": [
-"pe",
-"nha"
-]
-},
-{
-"word": "esguiar",
-"syllables": [
-"es",
-"gui",
-"ar"
-]
-},
-{
-"word": "fímbria",
-"syllables": [
-"fím",
-"bri",
-"a"
-]
-},
-{
-"word": "trovadoresco",
-"syllables": [
-"tro",
-"va",
-"do",
-"res",
-"co"
-]
-},
-{
-"word": "intento",
-"syllables": [
-"in",
-"ten",
-"to"
-]
-},
-{
-"word": "gláucio",
-"syllables": [
-"gláu",
-"ci",
-"o"
-]
-},
-{
-"word": "beijo",
-"syllables": [
-"bei",
-"jo"
-]
-},
-{
-"word": "curtume",
-"syllables": [
-"cur",
-"tu",
-"me"
-]
-},
-{
-"word": "contraforte",
-"syllables": [
-"con",
-"tra",
-"for",
-"te"
-]
-},
-{
-"word": "antipoético",
-"syllables": [
-"an",
-"ti",
-"po",
-"é",
-"ti",
-"co"
-]
-},
-{
-"word": "elegíaco",
-"syllables": [
-"e",
-"le",
-"gí",
-"a",
-"co"
-]
-},
-{
-"word": "aerotermo",
-"syllables": [
-"a",
-"e",
-"ro",
-"ter",
-"mo"
-]
-},
-{
-"word": "mentirola",
-"syllables": [
-"men",
-"ti",
-"ro",
-"la"
-]
-},
-{
-"word": "litográfico",
-"syllables": [
-"li",
-"to",
-"grá",
-"fi",
-"co"
-]
-},
-{
-"word": "convolar",
-"syllables": [
-"con",
-"vo",
-"lar"
-]
-},
-{
-"word": "menu",
-"syllables": [
-"me",
-"nu"
-]
-},
-{
-"word": "consultar",
-"syllables": [
-"con",
-"sul",
-"tar"
-]
-},
-{
-"word": "aburrar",
-"syllables": [
-"a",
-"bur",
-"rar"
-]
-},
-{
-"word": "aplacado",
-"syllables": [
-"a",
-"pla",
-"ca",
-"do"
-]
-},
-{
-"word": "presumida",
-"syllables": [
-"pre",
-"su",
-"mi",
-"da"
-]
-},
-{
-"word": "norma",
-"syllables": [
-"nor",
-"ma"
-]
-},
-{
-"word": "anticlímax",
-"syllables": [
-"an",
-"ti",
-"clí",
-"max"
-]
-},
-{
-"word": "convalescença",
-"syllables": [
-"con",
-"va",
-"les",
-"cen",
-"ça"
-]
-},
-{
-"word": "anunciador",
-"syllables": [
-"a",
-"nun",
-"ci",
-"a",
-"dor"
-]
-},
-{
-"word": "ultrainfernal",
-"syllables": [
-"ul",
-"tra",
-"in",
-"fer",
-"nal"
-]
-},
-{
-"word": "albanês",
-"syllables": [
-"al",
-"ba",
-"nês"
-]
-},
-{
-"word": "sáfico",
-"syllables": [
-"sá",
-"fi",
-"co"
-]
-},
-{
-"word": "dramaturgo",
-"syllables": [
-"dra",
-"ma",
-"tur",
-"go"
-]
-},
-{
-"word": "apiedar",
-"syllables": [
-"a",
-"pi",
-"e",
-"dar"
-]
-},
-{
-"word": "instintivo",
-"syllables": [
-"ins",
-"tin",
-"ti",
-"vo"
-]
-},
-{
-"word": "costado",
-"syllables": [
-"cos",
-"ta",
-"do"
-]
-},
-{
-"word": "descomposto",
-"syllables": [
-"des",
-"com",
-"pos",
-"to"
-]
-},
-{
-"word": "pedrada",
-"syllables": [
-"pe",
-"dra",
-"da"
-]
-},
-{
-"word": "improficuamente",
-"syllables": [
-"im",
-"pro",
-"fi",
-"cu",
-"a",
-"men",
-"te"
-]
-},
-{
-"word": "confidencialidade",
-"syllables": [
-"con",
-"fi",
-"den",
-"ci",
-"a",
-"li",
-"da",
-"de"
-]
-},
-{
-"word": "laguna",
-"syllables": [
-"la",
-"gu",
-"na"
-]
-},
-{
-"word": "bivalvular",
-"syllables": [
-"bi",
-"val",
-"vu",
-"lar"
-]
-},
-{
-"word": "pré-radical",
-"syllables": [
-"pré",
-"ra",
-"di",
-"cal"
-]
-},
-{
-"word": "zambujeiro",
-"syllables": [
-"zam",
-"bu",
-"jei",
-"ro"
-]
-},
-{
-"word": "tormentosamente",
-"syllables": [
-"tor",
-"men",
-"to",
-"sa",
-"men",
-"te"
-]
-},
-{
-"word": "manchinha",
-"syllables": [
-"man",
-"chi",
-"nha"
-]
-},
-{
-"word": "margarida",
-"syllables": [
-"mar",
-"ga",
-"ri",
-"da"
-]
-},
-{
-"word": "hondurenha",
-"syllables": [
-"hon",
-"du",
-"re",
-"nha"
-]
-},
-{
-"word": "cristaleira",
-"syllables": [
-"cris",
-"ta",
-"lei",
-"ra"
-]
-},
-{
-"word": "reticência",
-"syllables": [
-"re",
-"ti",
-"cên",
-"ci",
-"a"
-]
-},
-{
-"word": "honradez",
-"syllables": [
-"hon",
-"ra",
-"dez"
-]
-},
-{
-"word": "saqueador",
-"syllables": [
-"sa",
-"que",
-"a",
-"dor"
-]
-},
-{
-"word": "fanático",
-"syllables": [
-"fa",
-"ná",
-"ti",
-"co"
-]
-},
-{
-"word": "circunscrever",
-"syllables": [
-"cir",
-"cuns",
-"cre",
-"ver"
-]
-},
-{
-"word": "atingível",
-"syllables": [
-"a",
-"tin",
-"gí",
-"vel"
-]
-},
-{
-"word": "atualista",
-"syllables": [
-"a",
-"tu",
-"a",
-"lis",
-"ta"
-]
-},
-{
-"word": "parametrizável",
-"syllables": [
-"pa",
-"ra",
-"me",
-"tri",
-"zá",
-"vel"
-]
-},
-{
-"word": "fratricídio",
-"syllables": [
-"fra",
-"tri",
-"cí",
-"di",
-"o"
-]
-},
-{
-"word": "englobante",
-"syllables": [
-"en",
-"glo",
-"ban",
-"te"
-]
-},
-{
-"word": "folheta",
-"syllables": [
-"fo",
-"lhe",
-"ta"
-]
-},
-{
-"word": "feirense",
-"syllables": [
-"fei",
-"ren",
-"se"
-]
-},
-{
-"word": "hidrosfera",
-"syllables": [
-"hi",
-"dros",
-"fe",
-"ra"
-]
-},
-{
-"word": "tamanho",
-"syllables": [
-"ta",
-"ma",
-"nho"
-]
-},
-{
-"word": "purpurado",
-"syllables": [
-"pur",
-"pu",
-"ra",
-"do"
-]
-},
-{
-"word": "ansiedade",
-"syllables": [
-"an",
-"si",
-"e",
-"da",
-"de"
-]
-},
-{
-"word": "pequinês",
-"syllables": [
-"pe",
-"qui",
-"nês"
-]
-},
-{
-"word": "palestrante",
-"syllables": [
-"pa",
-"les",
-"tran",
-"te"
-]
-},
-{
-"word": "orfismo",
-"syllables": [
-"or",
-"fis",
-"mo"
-]
-},
-{
-"word": "ausente",
-"syllables": [
-"au",
-"sen",
-"te"
-]
-},
-{
-"word": "antiepiléptico",
-"syllables": [
-"an",
-"ti",
-"e",
-"pi",
-"lép",
-"ti",
-"co"
-]
-},
-{
-"word": "fabiana",
-"syllables": [
-"fa",
-"bi",
-"a",
-"na"
-]
-},
-{
-"word": "pum",
-"syllables": [
-"pum"
-]
-},
-{
-"word": "eletronegatividade",
-"syllables": [
-"e",
-"le",
-"tro",
-"ne",
-"ga",
-"ti",
-"vi",
-"da",
-"de"
-]
-},
-{
-"word": "sacarino",
-"syllables": [
-"sa",
-"ca",
-"ri",
-"no"
-]
-},
-{
-"word": "tabelião",
-"syllables": [
-"ta",
-"be",
-"li",
-"ão"
-]
-},
-{
-"word": "bacoca",
-"syllables": [
-"ba",
-"co",
-"ca"
-]
-},
-{
-"word": "cábula",
-"syllables": [
-"cá",
-"bu",
-"la"
-]
-},
-{
-"word": "civil",
-"syllables": [
-"ci",
-"vil"
-]
-},
-{
-"word": "circum-navegável",
-"syllables": [
-"cir",
-"cum",
-"na",
-"ve",
-"gá",
-"vel"
-]
-},
-{
-"word": "justamente",
-"syllables": [
-"jus",
-"ta",
-"men",
-"te"
-]
-},
-{
-"word": "germanófila",
-"syllables": [
-"ger",
-"ma",
-"nó",
-"fi",
-"la"
-]
-},
-{
-"word": "bravio",
-"syllables": [
-"bra",
-"vi",
-"o"
-]
-},
-{
-"word": "fluorescência",
-"syllables": [
-"flu",
-"o",
-"res",
-"cên",
-"ci",
-"a"
-]
-},
-{
-"word": "chibatar",
-"syllables": [
-"chi",
-"ba",
-"tar"
-]
-},
-{
-"word": "descomprimir",
-"syllables": [
-"des",
-"com",
-"pri",
-"mir"
-]
-},
-{
-"word": "hambúrguer",
-"syllables": [
-"ham",
-"búr",
-"guer"
-]
-},
-{
-"word": "cínica",
-"syllables": [
-"cí",
-"ni",
-"ca"
-]
-},
-{
-"word": "terrorífico",
-"syllables": [
-"ter",
-"ro",
-"rí",
-"fi",
-"co"
-]
-},
-{
-"word": "viciação",
-"syllables": [
-"vi",
-"ci",
-"a",
-"ção"
-]
-},
-{
-"word": "aquisitivo",
-"syllables": [
-"a",
-"qui",
-"si",
-"ti",
-"vo"
-]
-},
-{
-"word": "gargalhar",
-"syllables": [
-"gar",
-"ga",
-"lhar"
-]
-},
-{
-"word": "sardinhada",
-"syllables": [
-"sar",
-"di",
-"nha",
-"da"
-]
-},
-{
-"word": "súmula",
-"syllables": [
-"sú",
-"mu",
-"la"
-]
-},
-{
-"word": "supervisor",
-"syllables": [
-"su",
-"per",
-"vi",
-"sor"
-]
-},
-{
-"word": "lidado",
-"syllables": [
-"li",
-"da",
-"do"
-]
-},
-{
-"word": "augir",
-"syllables": [
-"au",
-"gir"
-]
-},
-{
-"word": "anelo",
-"syllables": [
-"a",
-"ne",
-"lo"
-]
-},
-{
-"word": "pagão",
-"syllables": [
-"pa",
-"gão"
-]
-},
-{
-"word": "lampa",
-"syllables": [
-"lam",
-"pa"
-]
-},
-{
-"word": "societária",
-"syllables": [
-"so",
-"ci",
-"e",
-"tá",
-"ri",
-"a"
-]
-},
-{
-"word": "adega",
-"syllables": [
-"a",
-"de",
-"ga"
-]
-},
-{
-"word": "atemorizado",
-"syllables": [
-"a",
-"te",
-"mo",
-"ri",
-"za",
-"do"
-]
-},
-{
-"word": "vinténio",
-"syllables": [
-"vin",
-"té",
-"ni",
-"o"
-]
-},
-{
-"word": "reconciliar",
-"syllables": [
-"re",
-"con",
-"ci",
-"li",
-"ar"
-]
-},
-{
-"word": "subscrição",
-"syllables": [
-"subs",
-"cri",
-"ção"
-]
-},
-{
-"word": "cortejar",
-"syllables": [
-"cor",
-"te",
-"jar"
-]
-},
-{
-"word": "carpir",
-"syllables": [
-"car",
-"pir"
-]
-},
-{
-"word": "faneco",
-"syllables": [
-"fa",
-"ne",
-"co"
-]
-},
-{
-"word": "improvisamente",
-"syllables": [
-"im",
-"pro",
-"vi",
-"sa",
-"men",
-"te"
-]
-},
-{
-"word": "imoralmente",
-"syllables": [
-"i",
-"mo",
-"ral",
-"men",
-"te"
-]
-},
-{
-"word": "confeitaria",
-"syllables": [
-"con",
-"fei",
-"ta",
-"ri",
-"a"
-]
-},
-{
-"word": "tanguista",
-"syllables": [
-"tan",
-"guis",
-"ta"
-]
-},
-{
-"word": "extraordinariamente",
-"syllables": [
-"ex",
-"tra",
-"or",
-"di",
-"na",
-"ri",
-"a",
-"men",
-"te"
-]
-},
-{
-"word": "turista",
-"syllables": [
-"tu",
-"ris",
-"ta"
-]
-},
-{
-"word": "antichoque",
-"syllables": [
-"an",
-"ti",
-"cho",
-"que"
-]
-},
-{
-"word": "cargueiro",
-"syllables": [
-"car",
-"guei",
-"ro"
-]
-},
-{
-"word": "espontâneo",
-"syllables": [
-"es",
-"pon",
-"tâ",
-"ne",
-"o"
-]
-},
-{
-"word": "abatinar",
-"syllables": [
-"a",
-"ba",
-"ti",
-"nar"
-]
-},
-{
-"word": "eternalmente",
-"syllables": [
-"e",
-"ter",
-"nal",
-"men",
-"te"
-]
-},
-{
-"word": "desacorde",
-"syllables": [
-"de",
-"sa",
-"cor",
-"de"
-]
-},
-{
-"word": "violaria",
-"syllables": [
-"vi",
-"o",
-"la",
-"ri",
-"a"
-]
-},
-{
-"word": "retanchar",
-"syllables": [
-"re",
-"tan",
-"char"
-]
-},
-{
-"word": "retorce",
-"syllables": [
-"re",
-"tor",
-"ce"
-]
-},
-{
-"word": "grampar",
-"syllables": [
-"gram",
-"par"
-]
-},
-{
-"word": "desencadernação",
-"syllables": [
-"de",
-"sen",
-"ca",
-"der",
-"na",
-"ção"
-]
-},
-{
-"word": "folclore",
-"syllables": [
-"fol",
-"clo",
-"re"
-]
-},
-{
-"word": "portada",
-"syllables": [
-"por",
-"ta",
-"da"
-]
-},
-{
-"word": "pê",
-"syllables": [
-"pê"
-]
-},
-{
-"word": "restolho",
-"syllables": [
-"res",
-"to",
-"lho"
-]
-},
-{
-"word": "logarítmico",
-"syllables": [
-"lo",
-"ga",
-"rít",
-"mi",
-"co"
-]
-},
-{
-"word": "particularista",
-"syllables": [
-"par",
-"ti",
-"cu",
-"la",
-"ris",
-"ta"
-]
-},
-{
-"word": "proto-histórico",
-"syllables": [
-"pro",
-"to",
-"his",
-"tó",
-"ri",
-"co"
-]
-},
-{
-"word": "imunossupressor",
-"syllables": [
-"i",
-"mu",
-"nos",
-"su",
-"pres",
-"sor"
-]
-},
-{
-"word": "cambiar",
-"syllables": [
-"cam",
-"bi",
-"ar"
-]
-},
-{
-"word": "circuito",
-"syllables": [
-"cir",
-"cui",
-"to"
-]
-},
-{
-"word": "deslustre",
-"syllables": [
-"des",
-"lus",
-"tre"
-]
-},
-{
-"word": "conseguinte",
-"syllables": [
-"con",
-"se",
-"guin",
-"te"
-]
-},
-{
-"word": "anticaspa",
-"syllables": [
-"an",
-"ti",
-"cas",
-"pa"
-]
-},
-{
-"word": "masculinizar",
-"syllables": [
-"mas",
-"cu",
-"li",
-"ni",
-"zar"
-]
-},
-{
-"word": "questor",
-"syllables": [
-"ques",
-"tor"
-]
-},
-{
-"word": "laranjinha",
-"syllables": [
-"la",
-"ran",
-"ji",
-"nha"
-]
-},
-{
-"word": "antieuropeísmo",
-"syllables": [
-"an",
-"ti",
-"eu",
-"ro",
-"pe",
-"ís",
-"mo"
-]
-},
-{
-"word": "rebatizar",
-"syllables": [
-"re",
-"ba",
-"ti",
-"zar"
-]
-},
-{
-"word": "diafonia",
-"syllables": [
-"di",
-"a",
-"fo",
-"ni",
-"a"
-]
-},
-{
-"word": "anti-humanístico",
-"syllables": [
-"an",
-"ti",
-"hu",
-"ma",
-"nís",
-"ti",
-"co"
-]
-},
-{
-"word": "andorinha",
-"syllables": [
-"an",
-"do",
-"ri",
-"nha"
-]
-},
-{
-"word": "meditativamente",
-"syllables": [
-"me",
-"di",
-"ta",
-"ti",
-"va",
-"men",
-"te"
-]
-},
-{
-"word": "identicamente",
-"syllables": [
-"i",
-"den",
-"ti",
-"ca",
-"men",
-"te"
-]
-},
-{
-"word": "inexecutável",
-"syllables": [
-"i",
-"ne",
-"xe",
-"cu",
-"tá",
-"vel"
-]
-},
-{
-"word": "verdizela",
-"syllables": [
-"ver",
-"di",
-"ze",
-"la"
-]
-},
-{
-"word": "sul-coreano",
-"syllables": [
-"sul",
-"co",
-"re",
-"a",
-"no"
-]
-},
-{
-"word": "jacarandá",
-"syllables": [
-"ja",
-"ca",
-"ran",
-"dá"
-]
-},
-{
-"word": "candear",
-"syllables": [
-"can",
-"de",
-"ar"
-]
-},
-{
-"word": "anti-heroico",
-"syllables": [
-"an",
-"ti",
-"he",
-"roi",
-"co"
-]
-},
-{
-"word": "ingovernável",
-"syllables": [
-"in",
-"go",
-"ver",
-"ná",
-"vel"
-]
-},
-{
-"word": "arqui-irmandade",
-"syllables": [
-"ar",
-"qui",
-"ir",
-"man",
-"da",
-"de"
-]
-},
-{
-"word": "sucrose",
-"syllables": [
-"su",
-"cro",
-"se"
-]
-},
-{
-"word": "chula",
-"syllables": [
-"chu",
-"la"
-]
-},
-{
-"word": "apalpão",
-"syllables": [
-"a",
-"pal",
-"pão"
-]
-},
-{
-"word": "microssociologia",
-"syllables": [
-"mi",
-"cros",
-"so",
-"ci",
-"o",
-"lo",
-"gi",
-"a"
-]
-},
-{
-"word": "apache",
-"syllables": [
-"a",
-"pa",
-"che"
-]
-},
-{
-"word": "perfuração",
-"syllables": [
-"per",
-"fu",
-"ra",
-"ção"
-]
-},
-{
-"word": "tablado",
-"syllables": [
-"ta",
-"bla",
-"do"
-]
-},
-{
-"word": "corretor",
-"syllables": [
-"cor",
-"re",
-"tor"
-]
-},
-{
-"word": "facultativo",
-"syllables": [
-"fa",
-"cul",
-"ta",
-"ti",
-"vo"
-]
-},
-{
-"word": "baía",
-"syllables": [
-"ba",
-"í",
-"a"
-]
-},
-{
-"word": "trasladação",
-"syllables": [
-"tras",
-"la",
-"da",
-"ção"
-]
-},
-{
-"word": "maltoso",
-"syllables": [
-"mal",
-"to",
-"so"
-]
-},
-{
-"word": "cultivador",
-"syllables": [
-"cul",
-"ti",
-"va",
-"dor"
-]
-},
-{
-"word": "mas",
-"syllables": [
-"mas"
-]
-},
-{
-"word": "micrológico",
-"syllables": [
-"mi",
-"cro",
-"ló",
-"gi",
-"co"
-]
-},
-{
-"word": "alterne",
-"syllables": [
-"al",
-"ter",
-"ne"
-]
-},
-{
-"word": "nacionalização",
-"syllables": [
-"na",
-"ci",
-"o",
-"na",
-"li",
-"za",
-"ção"
-]
-},
-{
-"word": "arrancada",
-"syllables": [
-"ar",
-"ran",
-"ca",
-"da"
-]
-},
-{
-"word": "fisicalidade",
-"syllables": [
-"fi",
-"si",
-"ca",
-"li",
-"da",
-"de"
-]
-},
-{
-"word": "papeleiro",
-"syllables": [
-"pa",
-"pe",
-"lei",
-"ro"
-]
-},
-{
-"word": "mediato",
-"syllables": [
-"me",
-"di",
-"a",
-"to"
-]
-},
-{
-"word": "magistratura",
-"syllables": [
-"ma",
-"gis",
-"tra",
-"tu",
-"ra"
-]
-},
-{
-"word": "intributável",
-"syllables": [
-"in",
-"tri",
-"bu",
-"tá",
-"vel"
-]
-},
-{
-"word": "difusão",
-"syllables": [
-"di",
-"fu",
-"são"
-]
-},
-{
-"word": "xiluva",
-"syllables": [
-"xi",
-"lu",
-"va"
-]
-},
-{
-"word": "denotar",
-"syllables": [
-"de",
-"no",
-"tar"
-]
-},
-{
-"word": "comercializável",
-"syllables": [
-"co",
-"mer",
-"ci",
-"a",
-"li",
-"zá",
-"vel"
-]
-},
-{
-"word": "peitoral",
-"syllables": [
-"pei",
-"to",
-"ral"
-]
-},
-{
-"word": "proplástico",
-"syllables": [
-"pro",
-"plás",
-"ti",
-"co"
-]
-},
-{
-"word": "dialéctico",
-"syllables": [
-"di",
-"a",
-"léc",
-"ti",
-"co"
-]
-},
-{
-"word": "cotização",
-"syllables": [
-"co",
-"ti",
-"za",
-"ção"
-]
-},
-{
-"word": "desadornado",
-"syllables": [
-"de",
-"sa",
-"dor",
-"na",
-"do"
-]
-},
-{
-"word": "exemplarmente",
-"syllables": [
-"e",
-"xem",
-"plar",
-"men",
-"te"
-]
-},
-{
-"word": "birreator",
-"syllables": [
-"bir",
-"re",
-"a",
-"tor"
-]
-},
-{
-"word": "oratório",
-"syllables": [
-"o",
-"ra",
-"tó",
-"ri",
-"o"
-]
-},
-{
-"word": "desnublar",
-"syllables": [
-"des",
-"nu",
-"blar"
-]
-},
-{
-"word": "grilar",
-"syllables": [
-"gri",
-"lar"
-]
-},
-{
-"word": "difuba",
-"syllables": [
-"di",
-"fu",
-"ba"
-]
-},
-{
-"word": "vitalmente",
-"syllables": [
-"vi",
-"tal",
-"men",
-"te"
-]
-},
-{
-"word": "reciprocidade",
-"syllables": [
-"re",
-"ci",
-"pro",
-"ci",
-"da",
-"de"
-]
-},
-{
-"word": "zaragatoar",
-"syllables": [
-"za",
-"ra",
-"ga",
-"to",
-"ar"
-]
-},
-{
-"word": "apotegma",
-"syllables": [
-"a",
-"po",
-"teg",
-"ma"
-]
-},
-{
-"word": "acelerador",
-"syllables": [
-"a",
-"ce",
-"le",
-"ra",
-"dor"
-]
-},
-{
-"word": "grupo",
-"syllables": [
-"gru",
-"po"
-]
-},
-{
-"word": "natalidade",
-"syllables": [
-"na",
-"ta",
-"li",
-"da",
-"de"
-]
-},
-{
-"word": "machim",
-"syllables": [
-"ma",
-"chim"
-]
-},
-{
-"word": "autocriticar",
-"syllables": [
-"au",
-"to",
-"cri",
-"ti",
-"car"
-]
-},
-{
-"word": "apresentavelmente",
-"syllables": [
-"a",
-"pre",
-"sen",
-"ta",
-"vel",
-"men",
-"te"
-]
-},
-{
-"word": "laboratório",
-"syllables": [
-"la",
-"bo",
-"ra",
-"tó",
-"ri",
-"o"
-]
-},
-{
-"word": "condoer",
-"syllables": [
-"con",
-"do",
-"er"
-]
-},
-{
-"word": "influído",
-"syllables": [
-"in",
-"flu",
-"í",
-"do"
-]
-},
-{
-"word": "bizantino",
-"syllables": [
-"bi",
-"zan",
-"ti",
-"no"
-]
-},
-{
-"word": "vátua",
-"syllables": [
-"vá",
-"tu",
-"a"
-]
-},
-{
-"word": "encefalograma",
-"syllables": [
-"en",
-"ce",
-"fa",
-"lo",
-"gra",
-"ma"
-]
-},
-{
-"word": "tombada",
-"syllables": [
-"tom",
-"ba",
-"da"
-]
-},
-{
-"word": "apara-lápis",
-"syllables": [
-"a",
-"pa",
-"ra",
-"lá",
-"pis"
-]
-},
-{
-"word": "tocador",
-"syllables": [
-"to",
-"ca",
-"dor"
-]
-},
-{
-"word": "cronógrafo",
-"syllables": [
-"cro",
-"nó",
-"gra",
-"fo"
-]
-},
-{
-"word": "esconso",
-"syllables": [
-"es",
-"con",
-"so"
-]
-},
-{
-"word": "desempolgar",
-"syllables": [
-"de",
-"sem",
-"pol",
-"gar"
-]
-},
-{
-"word": "candonga",
-"syllables": [
-"can",
-"don",
-"ga"
-]
-},
-{
-"word": "físico-químico",
-"syllables": [
-"fí",
-"si",
-"co",
-"quí",
-"mi",
-"co"
-]
-},
-{
-"word": "sobreolho",
-"syllables": [
-"so",
-"bre",
-"o",
-"lho"
-]
-},
-{
-"word": "latino",
-"syllables": [
-"la",
-"ti",
-"no"
-]
-},
-{
-"word": "preferente",
-"syllables": [
-"pre",
-"fe",
-"ren",
-"te"
-]
-},
-{
-"word": "despejadamente",
-"syllables": [
-"des",
-"pe",
-"ja",
-"da",
-"men",
-"te"
-]
-},
-{
-"word": "movimentar",
-"syllables": [
-"mo",
-"vi",
-"men",
-"tar"
-]
-},
-{
-"word": "sapador",
-"syllables": [
-"sa",
-"pa",
-"dor"
-]
-}
-]
+ "source": "TigreGotico/portuguese-unified-pronunciation-lexicon",
+ "gold": "agreement (infopedia + portal, identical split, join-integrity checked)",
+ "split": "test (held out)",
+ "entries": [
+  {
+   "word": "moqueca",
+   "syllables": [
+    "mo",
+    "que",
+    "ca"
+   ]
+  },
+  {
+   "word": "cosmógrafo",
+   "syllables": [
+    "cos",
+    "mó",
+    "gra",
+    "fo"
+   ]
+  },
+  {
+   "word": "embalsamar",
+   "syllables": [
+    "em",
+    "bal",
+    "sa",
+    "mar"
+   ]
+  },
+  {
+   "word": "toga",
+   "syllables": [
+    "to",
+    "ga"
+   ]
+  },
+  {
+   "word": "geladeira",
+   "syllables": [
+    "ge",
+    "la",
+    "dei",
+    "ra"
+   ]
+  },
+  {
+   "word": "boletim",
+   "syllables": [
+    "bo",
+    "le",
+    "tim"
+   ]
+  },
+  {
+   "word": "antidemocrático",
+   "syllables": [
+    "an",
+    "ti",
+    "de",
+    "mo",
+    "crá",
+    "ti",
+    "co"
+   ]
+  },
+  {
+   "word": "grato",
+   "syllables": [
+    "gra",
+    "to"
+   ]
+  },
+  {
+   "word": "larvar",
+   "syllables": [
+    "lar",
+    "var"
+   ]
+  },
+  {
+   "word": "fécula",
+   "syllables": [
+    "fé",
+    "cu",
+    "la"
+   ]
+  },
+  {
+   "word": "repousar",
+   "syllables": [
+    "re",
+    "pou",
+    "sar"
+   ]
+  },
+  {
+   "word": "dentada",
+   "syllables": [
+    "den",
+    "ta",
+    "da"
+   ]
+  },
+  {
+   "word": "chupeta",
+   "syllables": [
+    "chu",
+    "pe",
+    "ta"
+   ]
+  },
+  {
+   "word": "beluga",
+   "syllables": [
+    "be",
+    "lu",
+    "ga"
+   ]
+  },
+  {
+   "word": "reimportação",
+   "syllables": [
+    "re",
+    "im",
+    "por",
+    "ta",
+    "ção"
+   ]
+  },
+  {
+   "word": "defraudar",
+   "syllables": [
+    "de",
+    "frau",
+    "dar"
+   ]
+  },
+  {
+   "word": "blocagem",
+   "syllables": [
+    "blo",
+    "ca",
+    "gem"
+   ]
+  },
+  {
+   "word": "imediatismo",
+   "syllables": [
+    "i",
+    "me",
+    "di",
+    "a",
+    "tis",
+    "mo"
+   ]
+  },
+  {
+   "word": "constantemente",
+   "syllables": [
+    "cons",
+    "tan",
+    "te",
+    "men",
+    "te"
+   ]
+  },
+  {
+   "word": "chassis",
+   "syllables": [
+    "chas",
+    "sis"
+   ]
+  },
+  {
+   "word": "desaforro",
+   "syllables": [
+    "de",
+    "sa",
+    "for",
+    "ro"
+   ]
+  },
+  {
+   "word": "alforriar",
+   "syllables": [
+    "al",
+    "for",
+    "ri",
+    "ar"
+   ]
+  },
+  {
+   "word": "figura",
+   "syllables": [
+    "fi",
+    "gu",
+    "ra"
+   ]
+  },
+  {
+   "word": "seda",
+   "syllables": [
+    "se",
+    "da"
+   ]
+  },
+  {
+   "word": "escarificação",
+   "syllables": [
+    "es",
+    "ca",
+    "ri",
+    "fi",
+    "ca",
+    "ção"
+   ]
+  },
+  {
+   "word": "crespo",
+   "syllables": [
+    "cres",
+    "po"
+   ]
+  },
+  {
+   "word": "acasalado",
+   "syllables": [
+    "a",
+    "ca",
+    "sa",
+    "la",
+    "do"
+   ]
+  },
+  {
+   "word": "traquitana",
+   "syllables": [
+    "tra",
+    "qui",
+    "ta",
+    "na"
+   ]
+  },
+  {
+   "word": "lata",
+   "syllables": [
+    "la",
+    "ta"
+   ]
+  },
+  {
+   "word": "mutilação",
+   "syllables": [
+    "mu",
+    "ti",
+    "la",
+    "ção"
+   ]
+  },
+  {
+   "word": "descuriosidade",
+   "syllables": [
+    "des",
+    "cu",
+    "ri",
+    "o",
+    "si",
+    "da",
+    "de"
+   ]
+  },
+  {
+   "word": "furador",
+   "syllables": [
+    "fu",
+    "ra",
+    "dor"
+   ]
+  },
+  {
+   "word": "cagarola",
+   "syllables": [
+    "ca",
+    "ga",
+    "ro",
+    "la"
+   ]
+  },
+  {
+   "word": "bilião",
+   "syllables": [
+    "bi",
+    "li",
+    "ão"
+   ]
+  },
+  {
+   "word": "desempacotar",
+   "syllables": [
+    "de",
+    "sem",
+    "pa",
+    "co",
+    "tar"
+   ]
+  },
+  {
+   "word": "bolsista",
+   "syllables": [
+    "bol",
+    "sis",
+    "ta"
+   ]
+  },
+  {
+   "word": "rocinante",
+   "syllables": [
+    "ro",
+    "ci",
+    "nan",
+    "te"
+   ]
+  },
+  {
+   "word": "dicção",
+   "syllables": [
+    "dic",
+    "ção"
+   ]
+  },
+  {
+   "word": "seta",
+   "syllables": [
+    "se",
+    "ta"
+   ]
+  },
+  {
+   "word": "inumar",
+   "syllables": [
+    "i",
+    "nu",
+    "mar"
+   ]
+  },
+  {
+   "word": "descortejar",
+   "syllables": [
+    "des",
+    "cor",
+    "te",
+    "jar"
+   ]
+  },
+  {
+   "word": "espinheira",
+   "syllables": [
+    "es",
+    "pi",
+    "nhei",
+    "ra"
+   ]
+  },
+  {
+   "word": "metafisicar",
+   "syllables": [
+    "me",
+    "ta",
+    "fi",
+    "si",
+    "car"
+   ]
+  },
+  {
+   "word": "cromossómico",
+   "syllables": [
+    "cro",
+    "mos",
+    "só",
+    "mi",
+    "co"
+   ]
+  },
+  {
+   "word": "degelo",
+   "syllables": [
+    "de",
+    "ge",
+    "lo"
+   ]
+  },
+  {
+   "word": "dissaboroso",
+   "syllables": [
+    "dis",
+    "sa",
+    "bo",
+    "ro",
+    "so"
+   ]
+  },
+  {
+   "word": "fresquidão",
+   "syllables": [
+    "fres",
+    "qui",
+    "dão"
+   ]
+  },
+  {
+   "word": "urgência",
+   "syllables": [
+    "ur",
+    "gên",
+    "ci",
+    "a"
+   ]
+  },
+  {
+   "word": "inferiorização",
+   "syllables": [
+    "in",
+    "fe",
+    "ri",
+    "o",
+    "ri",
+    "za",
+    "ção"
+   ]
+  },
+  {
+   "word": "aditar",
+   "syllables": [
+    "a",
+    "di",
+    "tar"
+   ]
+  },
+  {
+   "word": "bifana",
+   "syllables": [
+    "bi",
+    "fa",
+    "na"
+   ]
+  },
+  {
+   "word": "dessalinizar",
+   "syllables": [
+    "des",
+    "sa",
+    "li",
+    "ni",
+    "zar"
+   ]
+  },
+  {
+   "word": "fardo",
+   "syllables": [
+    "far",
+    "do"
+   ]
+  },
+  {
+   "word": "melena",
+   "syllables": [
+    "me",
+    "le",
+    "na"
+   ]
+  },
+  {
+   "word": "agrogeologia",
+   "syllables": [
+    "a",
+    "gro",
+    "ge",
+    "o",
+    "lo",
+    "gi",
+    "a"
+   ]
+  },
+  {
+   "word": "confidente",
+   "syllables": [
+    "con",
+    "fi",
+    "den",
+    "te"
+   ]
+  },
+  {
+   "word": "juliano",
+   "syllables": [
+    "ju",
+    "li",
+    "a",
+    "no"
+   ]
+  },
+  {
+   "word": "carestia",
+   "syllables": [
+    "ca",
+    "res",
+    "ti",
+    "a"
+   ]
+  },
+  {
+   "word": "obcecado",
+   "syllables": [
+    "ob",
+    "ce",
+    "ca",
+    "do"
+   ]
+  },
+  {
+   "word": "alfanumérico",
+   "syllables": [
+    "al",
+    "fa",
+    "nu",
+    "mé",
+    "ri",
+    "co"
+   ]
+  },
+  {
+   "word": "oncogénese",
+   "syllables": [
+    "on",
+    "co",
+    "gé",
+    "ne",
+    "se"
+   ]
+  },
+  {
+   "word": "epifania",
+   "syllables": [
+    "e",
+    "pi",
+    "fa",
+    "ni",
+    "a"
+   ]
+  },
+  {
+   "word": "faroleiro",
+   "syllables": [
+    "fa",
+    "ro",
+    "lei",
+    "ro"
+   ]
+  },
+  {
+   "word": "retardar",
+   "syllables": [
+    "re",
+    "tar",
+    "dar"
+   ]
+  },
+  {
+   "word": "chamejante",
+   "syllables": [
+    "cha",
+    "me",
+    "jan",
+    "te"
+   ]
+  },
+  {
+   "word": "microgravidade",
+   "syllables": [
+    "mi",
+    "cro",
+    "gra",
+    "vi",
+    "da",
+    "de"
+   ]
+  },
+  {
+   "word": "espalmado",
+   "syllables": [
+    "es",
+    "pal",
+    "ma",
+    "do"
+   ]
+  },
+  {
+   "word": "nenhum",
+   "syllables": [
+    "ne",
+    "nhum"
+   ]
+  },
+  {
+   "word": "curiosamente",
+   "syllables": [
+    "cu",
+    "ri",
+    "o",
+    "sa",
+    "men",
+    "te"
+   ]
+  },
+  {
+   "word": "capuchar",
+   "syllables": [
+    "ca",
+    "pu",
+    "char"
+   ]
+  },
+  {
+   "word": "chui",
+   "syllables": [
+    "chui"
+   ]
+  },
+  {
+   "word": "rugir",
+   "syllables": [
+    "ru",
+    "gir"
+   ]
+  },
+  {
+   "word": "bianual",
+   "syllables": [
+    "bi",
+    "a",
+    "nu",
+    "al"
+   ]
+  },
+  {
+   "word": "inalienável",
+   "syllables": [
+    "i",
+    "na",
+    "li",
+    "e",
+    "ná",
+    "vel"
+   ]
+  },
+  {
+   "word": "egoísmo",
+   "syllables": [
+    "e",
+    "go",
+    "ís",
+    "mo"
+   ]
+  },
+  {
+   "word": "crescer",
+   "syllables": [
+    "cres",
+    "cer"
+   ]
+  },
+  {
+   "word": "paginação",
+   "syllables": [
+    "pa",
+    "gi",
+    "na",
+    "ção"
+   ]
+  },
+  {
+   "word": "lixeira",
+   "syllables": [
+    "li",
+    "xei",
+    "ra"
+   ]
+  },
+  {
+   "word": "bejense",
+   "syllables": [
+    "be",
+    "jen",
+    "se"
+   ]
+  },
+  {
+   "word": "tábua",
+   "syllables": [
+    "tá",
+    "bu",
+    "a"
+   ]
+  },
+  {
+   "word": "dizimar",
+   "syllables": [
+    "di",
+    "zi",
+    "mar"
+   ]
+  },
+  {
+   "word": "desengrossamento",
+   "syllables": [
+    "de",
+    "sen",
+    "gros",
+    "sa",
+    "men",
+    "to"
+   ]
+  },
+  {
+   "word": "despalmilhar",
+   "syllables": [
+    "des",
+    "pal",
+    "mi",
+    "lhar"
+   ]
+  },
+  {
+   "word": "extrapolação",
+   "syllables": [
+    "ex",
+    "tra",
+    "po",
+    "la",
+    "ção"
+   ]
+  },
+  {
+   "word": "ingente",
+   "syllables": [
+    "in",
+    "gen",
+    "te"
+   ]
+  },
+  {
+   "word": "cabala",
+   "syllables": [
+    "ca",
+    "ba",
+    "la"
+   ]
+  },
+  {
+   "word": "carapeta",
+   "syllables": [
+    "ca",
+    "ra",
+    "pe",
+    "ta"
+   ]
+  },
+  {
+   "word": "surpreendentemente",
+   "syllables": [
+    "sur",
+    "pre",
+    "en",
+    "den",
+    "te",
+    "men",
+    "te"
+   ]
+  },
+  {
+   "word": "deponente",
+   "syllables": [
+    "de",
+    "po",
+    "nen",
+    "te"
+   ]
+  },
+  {
+   "word": "costal",
+   "syllables": [
+    "cos",
+    "tal"
+   ]
+  },
+  {
+   "word": "evidente",
+   "syllables": [
+    "e",
+    "vi",
+    "den",
+    "te"
+   ]
+  },
+  {
+   "word": "malquistar",
+   "syllables": [
+    "mal",
+    "quis",
+    "tar"
+   ]
+  },
+  {
+   "word": "indicado",
+   "syllables": [
+    "in",
+    "di",
+    "ca",
+    "do"
+   ]
+  },
+  {
+   "word": "fortalecimento",
+   "syllables": [
+    "for",
+    "ta",
+    "le",
+    "ci",
+    "men",
+    "to"
+   ]
+  },
+  {
+   "word": "insuflar",
+   "syllables": [
+    "in",
+    "su",
+    "flar"
+   ]
+  },
+  {
+   "word": "airosamente",
+   "syllables": [
+    "ai",
+    "ro",
+    "sa",
+    "men",
+    "te"
+   ]
+  },
+  {
+   "word": "papar",
+   "syllables": [
+    "pa",
+    "par"
+   ]
+  },
+  {
+   "word": "antevoar",
+   "syllables": [
+    "an",
+    "te",
+    "vo",
+    "ar"
+   ]
+  },
+  {
+   "word": "berço",
+   "syllables": [
+    "ber",
+    "ço"
+   ]
+  },
+  {
+   "word": "fornicação",
+   "syllables": [
+    "for",
+    "ni",
+    "ca",
+    "ção"
+   ]
+  },
+  {
+   "word": "desafogado",
+   "syllables": [
+    "de",
+    "sa",
+    "fo",
+    "ga",
+    "do"
+   ]
+  },
+  {
+   "word": "coxim",
+   "syllables": [
+    "co",
+    "xim"
+   ]
+  },
+  {
+   "word": "alerta",
+   "syllables": [
+    "a",
+    "ler",
+    "ta"
+   ]
+  },
+  {
+   "word": "manada",
+   "syllables": [
+    "ma",
+    "na",
+    "da"
+   ]
+  },
+  {
+   "word": "macrocefalia",
+   "syllables": [
+    "ma",
+    "cro",
+    "ce",
+    "fa",
+    "li",
+    "a"
+   ]
+  },
+  {
+   "word": "pegajoso",
+   "syllables": [
+    "pe",
+    "ga",
+    "jo",
+    "so"
+   ]
+  },
+  {
+   "word": "festa",
+   "syllables": [
+    "fes",
+    "ta"
+   ]
+  },
+  {
+   "word": "chapinhar",
+   "syllables": [
+    "cha",
+    "pi",
+    "nhar"
+   ]
+  },
+  {
+   "word": "publicidade",
+   "syllables": [
+    "pu",
+    "bli",
+    "ci",
+    "da",
+    "de"
+   ]
+  },
+  {
+   "word": "neurose",
+   "syllables": [
+    "neu",
+    "ro",
+    "se"
+   ]
+  },
+  {
+   "word": "baldo",
+   "syllables": [
+    "bal",
+    "do"
+   ]
+  },
+  {
+   "word": "apedrejador",
+   "syllables": [
+    "a",
+    "pe",
+    "dre",
+    "ja",
+    "dor"
+   ]
+  },
+  {
+   "word": "contato",
+   "syllables": [
+    "con",
+    "ta",
+    "to"
+   ]
+  },
+  {
+   "word": "fintar",
+   "syllables": [
+    "fin",
+    "tar"
+   ]
+  },
+  {
+   "word": "falange",
+   "syllables": [
+    "fa",
+    "lan",
+    "ge"
+   ]
+  },
+  {
+   "word": "apostolicamente",
+   "syllables": [
+    "a",
+    "pos",
+    "to",
+    "li",
+    "ca",
+    "men",
+    "te"
+   ]
+  },
+  {
+   "word": "planeamento",
+   "syllables": [
+    "pla",
+    "ne",
+    "a",
+    "men",
+    "to"
+   ]
+  },
+  {
+   "word": "afélio",
+   "syllables": [
+    "a",
+    "fé",
+    "li",
+    "o"
+   ]
+  },
+  {
+   "word": "assenhorar",
+   "syllables": [
+    "as",
+    "se",
+    "nho",
+    "rar"
+   ]
+  },
+  {
+   "word": "giga",
+   "syllables": [
+    "gi",
+    "ga"
+   ]
+  },
+  {
+   "word": "garantia",
+   "syllables": [
+    "ga",
+    "ran",
+    "ti",
+    "a"
+   ]
+  },
+  {
+   "word": "maldição",
+   "syllables": [
+    "mal",
+    "di",
+    "ção"
+   ]
+  },
+  {
+   "word": "discipulado",
+   "syllables": [
+    "dis",
+    "ci",
+    "pu",
+    "la",
+    "do"
+   ]
+  },
+  {
+   "word": "sectarismo",
+   "syllables": [
+    "sec",
+    "ta",
+    "ris",
+    "mo"
+   ]
+  },
+  {
+   "word": "desparra",
+   "syllables": [
+    "des",
+    "par",
+    "ra"
+   ]
+  },
+  {
+   "word": "deslaçar",
+   "syllables": [
+    "des",
+    "la",
+    "çar"
+   ]
+  },
+  {
+   "word": "mantra",
+   "syllables": [
+    "man",
+    "tra"
+   ]
+  },
+  {
+   "word": "anotar",
+   "syllables": [
+    "a",
+    "no",
+    "tar"
+   ]
+  },
+  {
+   "word": "frequentar",
+   "syllables": [
+    "fre",
+    "quen",
+    "tar"
+   ]
+  },
+  {
+   "word": "junça",
+   "syllables": [
+    "jun",
+    "ça"
+   ]
+  },
+  {
+   "word": "respeitável",
+   "syllables": [
+    "res",
+    "pei",
+    "tá",
+    "vel"
+   ]
+  },
+  {
+   "word": "depauperamento",
+   "syllables": [
+    "de",
+    "pau",
+    "pe",
+    "ra",
+    "men",
+    "to"
+   ]
+  },
+  {
+   "word": "cintar",
+   "syllables": [
+    "cin",
+    "tar"
+   ]
+  },
+  {
+   "word": "longínquo",
+   "syllables": [
+    "lon",
+    "gín",
+    "quo"
+   ]
+  },
+  {
+   "word": "reflorescer",
+   "syllables": [
+    "re",
+    "flo",
+    "res",
+    "cer"
+   ]
+  },
+  {
+   "word": "hidromecânica",
+   "syllables": [
+    "hi",
+    "dro",
+    "me",
+    "câ",
+    "ni",
+    "ca"
+   ]
+  },
+  {
+   "word": "bordoada",
+   "syllables": [
+    "bor",
+    "do",
+    "a",
+    "da"
+   ]
+  },
+  {
+   "word": "dica",
+   "syllables": [
+    "di",
+    "ca"
+   ]
+  },
+  {
+   "word": "ganguela",
+   "syllables": [
+    "gan",
+    "gue",
+    "la"
+   ]
+  },
+  {
+   "word": "derretido",
+   "syllables": [
+    "der",
+    "re",
+    "ti",
+    "do"
+   ]
+  },
+  {
+   "word": "inacreditável",
+   "syllables": [
+    "i",
+    "na",
+    "cre",
+    "di",
+    "tá",
+    "vel"
+   ]
+  },
+  {
+   "word": "caide",
+   "syllables": [
+    "cai",
+    "de"
+   ]
+  },
+  {
+   "word": "caudaloso",
+   "syllables": [
+    "cau",
+    "da",
+    "lo",
+    "so"
+   ]
+  },
+  {
+   "word": "demasiar",
+   "syllables": [
+    "de",
+    "ma",
+    "si",
+    "ar"
+   ]
+  },
+  {
+   "word": "revide",
+   "syllables": [
+    "re",
+    "vi",
+    "de"
+   ]
+  },
+  {
+   "word": "prometedoramente",
+   "syllables": [
+    "pro",
+    "me",
+    "te",
+    "do",
+    "ra",
+    "men",
+    "te"
+   ]
+  },
+  {
+   "word": "augar",
+   "syllables": [
+    "au",
+    "gar"
+   ]
+  },
+  {
+   "word": "cadelo",
+   "syllables": [
+    "ca",
+    "de",
+    "lo"
+   ]
+  },
+  {
+   "word": "exão",
+   "syllables": [
+    "e",
+    "xão"
+   ]
+  },
+  {
+   "word": "catamarã",
+   "syllables": [
+    "ca",
+    "ta",
+    "ma",
+    "rã"
+   ]
+  },
+  {
+   "word": "antifurto",
+   "syllables": [
+    "an",
+    "ti",
+    "fur",
+    "to"
+   ]
+  },
+  {
+   "word": "traçado",
+   "syllables": [
+    "tra",
+    "ça",
+    "do"
+   ]
+  },
+  {
+   "word": "improdutivo",
+   "syllables": [
+    "im",
+    "pro",
+    "du",
+    "ti",
+    "vo"
+   ]
+  },
+  {
+   "word": "rocha",
+   "syllables": [
+    "ro",
+    "cha"
+   ]
+  },
+  {
+   "word": "anacronicamente",
+   "syllables": [
+    "a",
+    "na",
+    "cro",
+    "ni",
+    "ca",
+    "men",
+    "te"
+   ]
+  },
+  {
+   "word": "bronzeamento",
+   "syllables": [
+    "bron",
+    "ze",
+    "a",
+    "men",
+    "to"
+   ]
+  },
+  {
+   "word": "impensável",
+   "syllables": [
+    "im",
+    "pen",
+    "sá",
+    "vel"
+   ]
+  },
+  {
+   "word": "garganta",
+   "syllables": [
+    "gar",
+    "gan",
+    "ta"
+   ]
+  },
+  {
+   "word": "estéril",
+   "syllables": [
+    "es",
+    "té",
+    "ril"
+   ]
+  },
+  {
+   "word": "atleticamente",
+   "syllables": [
+    "a",
+    "tle",
+    "ti",
+    "ca",
+    "men",
+    "te"
+   ]
+  },
+  {
+   "word": "domar",
+   "syllables": [
+    "do",
+    "mar"
+   ]
+  },
+  {
+   "word": "vicariato",
+   "syllables": [
+    "vi",
+    "ca",
+    "ri",
+    "a",
+    "to"
+   ]
+  },
+  {
+   "word": "síria",
+   "syllables": [
+    "sí",
+    "ri",
+    "a"
+   ]
+  },
+  {
+   "word": "acautelado",
+   "syllables": [
+    "a",
+    "cau",
+    "te",
+    "la",
+    "do"
+   ]
+  },
+  {
+   "word": "cardal",
+   "syllables": [
+    "car",
+    "dal"
+   ]
+  },
+  {
+   "word": "bramanismo",
+   "syllables": [
+    "bra",
+    "ma",
+    "nis",
+    "mo"
+   ]
+  },
+  {
+   "word": "ortigar",
+   "syllables": [
+    "or",
+    "ti",
+    "gar"
+   ]
+  },
+  {
+   "word": "destilar",
+   "syllables": [
+    "des",
+    "ti",
+    "lar"
+   ]
+  },
+  {
+   "word": "congratulação",
+   "syllables": [
+    "con",
+    "gra",
+    "tu",
+    "la",
+    "ção"
+   ]
+  },
+  {
+   "word": "gando",
+   "syllables": [
+    "gan",
+    "do"
+   ]
+  },
+  {
+   "word": "glote",
+   "syllables": [
+    "glo",
+    "te"
+   ]
+  },
+  {
+   "word": "excremento",
+   "syllables": [
+    "ex",
+    "cre",
+    "men",
+    "to"
+   ]
+  },
+  {
+   "word": "hematúria",
+   "syllables": [
+    "he",
+    "ma",
+    "tú",
+    "ri",
+    "a"
+   ]
+  },
+  {
+   "word": "bicorcovado",
+   "syllables": [
+    "bi",
+    "cor",
+    "co",
+    "va",
+    "do"
+   ]
+  },
+  {
+   "word": "cossecante",
+   "syllables": [
+    "cos",
+    "se",
+    "can",
+    "te"
+   ]
+  },
+  {
+   "word": "tradicionalista",
+   "syllables": [
+    "tra",
+    "di",
+    "ci",
+    "o",
+    "na",
+    "lis",
+    "ta"
+   ]
+  },
+  {
+   "word": "reforma",
+   "syllables": [
+    "re",
+    "for",
+    "ma"
+   ]
+  },
+  {
+   "word": "recalcificação",
+   "syllables": [
+    "re",
+    "cal",
+    "ci",
+    "fi",
+    "ca",
+    "ção"
+   ]
+  },
+  {
+   "word": "marista",
+   "syllables": [
+    "ma",
+    "ris",
+    "ta"
+   ]
+  },
+  {
+   "word": "desaprovação",
+   "syllables": [
+    "de",
+    "sa",
+    "pro",
+    "va",
+    "ção"
+   ]
+  },
+  {
+   "word": "anavalhar",
+   "syllables": [
+    "a",
+    "na",
+    "va",
+    "lhar"
+   ]
+  },
+  {
+   "word": "agonizar",
+   "syllables": [
+    "a",
+    "go",
+    "ni",
+    "zar"
+   ]
+  },
+  {
+   "word": "catarse",
+   "syllables": [
+    "ca",
+    "tar",
+    "se"
+   ]
+  },
+  {
+   "word": "contundir",
+   "syllables": [
+    "con",
+    "tun",
+    "dir"
+   ]
+  },
+  {
+   "word": "analista",
+   "syllables": [
+    "a",
+    "na",
+    "lis",
+    "ta"
+   ]
+  },
+  {
+   "word": "cangalheiro",
+   "syllables": [
+    "can",
+    "ga",
+    "lhei",
+    "ro"
+   ]
+  },
+  {
+   "word": "ressequir",
+   "syllables": [
+    "res",
+    "se",
+    "quir"
+   ]
+  },
+  {
+   "word": "arpão",
+   "syllables": [
+    "ar",
+    "pão"
+   ]
+  },
+  {
+   "word": "descobrir",
+   "syllables": [
+    "des",
+    "co",
+    "brir"
+   ]
+  },
+  {
+   "word": "enfornar",
+   "syllables": [
+    "en",
+    "for",
+    "nar"
+   ]
+  },
+  {
+   "word": "autobus",
+   "syllables": [
+    "au",
+    "to",
+    "bus"
+   ]
+  },
+  {
+   "word": "sabido",
+   "syllables": [
+    "sa",
+    "bi",
+    "do"
+   ]
+  },
+  {
+   "word": "pedinte",
+   "syllables": [
+    "pe",
+    "din",
+    "te"
+   ]
+  },
+  {
+   "word": "arguente",
+   "syllables": [
+    "ar",
+    "guen",
+    "te"
+   ]
+  },
+  {
+   "word": "salgueiral",
+   "syllables": [
+    "sal",
+    "guei",
+    "ral"
+   ]
+  },
+  {
+   "word": "rasca",
+   "syllables": [
+    "ras",
+    "ca"
+   ]
+  },
+  {
+   "word": "cambal",
+   "syllables": [
+    "cam",
+    "bal"
+   ]
+  },
+  {
+   "word": "keynesianismo",
+   "syllables": [
+    "key",
+    "ne",
+    "si",
+    "a",
+    "nis",
+    "mo"
+   ]
+  },
+  {
+   "word": "dopar",
+   "syllables": [
+    "do",
+    "par"
+   ]
+  },
+  {
+   "word": "rabugice",
+   "syllables": [
+    "ra",
+    "bu",
+    "gi",
+    "ce"
+   ]
+  },
+  {
+   "word": "assinante",
+   "syllables": [
+    "as",
+    "si",
+    "nan",
+    "te"
+   ]
+  },
+  {
+   "word": "circunflexo",
+   "syllables": [
+    "cir",
+    "cun",
+    "fle",
+    "xo"
+   ]
+  },
+  {
+   "word": "bolsinho",
+   "syllables": [
+    "bol",
+    "si",
+    "nho"
+   ]
+  },
+  {
+   "word": "gandaiar",
+   "syllables": [
+    "gan",
+    "dai",
+    "ar"
+   ]
+  },
+  {
+   "word": "fulguração",
+   "syllables": [
+    "ful",
+    "gu",
+    "ra",
+    "ção"
+   ]
+  },
+  {
+   "word": "peno",
+   "syllables": [
+    "pe",
+    "no"
+   ]
+  },
+  {
+   "word": "desagastar",
+   "syllables": [
+    "de",
+    "sa",
+    "gas",
+    "tar"
+   ]
+  },
+  {
+   "word": "mangação",
+   "syllables": [
+    "man",
+    "ga",
+    "ção"
+   ]
+  },
+  {
+   "word": "debotado",
+   "syllables": [
+    "de",
+    "bo",
+    "ta",
+    "do"
+   ]
+  },
+  {
+   "word": "anarquicamente",
+   "syllables": [
+    "a",
+    "nar",
+    "qui",
+    "ca",
+    "men",
+    "te"
+   ]
+  },
+  {
+   "word": "protozoário",
+   "syllables": [
+    "pro",
+    "to",
+    "zo",
+    "á",
+    "ri",
+    "o"
+   ]
+  },
+  {
+   "word": "cooperador",
+   "syllables": [
+    "co",
+    "o",
+    "pe",
+    "ra",
+    "dor"
+   ]
+  },
+  {
+   "word": "ralação",
+   "syllables": [
+    "ra",
+    "la",
+    "ção"
+   ]
+  },
+  {
+   "word": "mana",
+   "syllables": [
+    "ma",
+    "na"
+   ]
+  },
+  {
+   "word": "diretiva",
+   "syllables": [
+    "di",
+    "re",
+    "ti",
+    "va"
+   ]
+  },
+  {
+   "word": "caramanchão",
+   "syllables": [
+    "ca",
+    "ra",
+    "man",
+    "chão"
+   ]
+  },
+  {
+   "word": "maiêutica",
+   "syllables": [
+    "mai",
+    "êu",
+    "ti",
+    "ca"
+   ]
+  },
+  {
+   "word": "geniturinário",
+   "syllables": [
+    "ge",
+    "ni",
+    "tu",
+    "ri",
+    "ná",
+    "ri",
+    "o"
+   ]
+  },
+  {
+   "word": "cortelha",
+   "syllables": [
+    "cor",
+    "te",
+    "lha"
+   ]
+  },
+  {
+   "word": "mirense",
+   "syllables": [
+    "mi",
+    "ren",
+    "se"
+   ]
+  },
+  {
+   "word": "toco",
+   "syllables": [
+    "to",
+    "co"
+   ]
+  },
+  {
+   "word": "assinar",
+   "syllables": [
+    "as",
+    "si",
+    "nar"
+   ]
+  },
+  {
+   "word": "cachaço",
+   "syllables": [
+    "ca",
+    "cha",
+    "ço"
+   ]
+  },
+  {
+   "word": "incomodado",
+   "syllables": [
+    "in",
+    "co",
+    "mo",
+    "da",
+    "do"
+   ]
+  },
+  {
+   "word": "pretalhão",
+   "syllables": [
+    "pre",
+    "ta",
+    "lhão"
+   ]
+  },
+  {
+   "word": "cabritar",
+   "syllables": [
+    "ca",
+    "bri",
+    "tar"
+   ]
+  },
+  {
+   "word": "vilanagem",
+   "syllables": [
+    "vi",
+    "la",
+    "na",
+    "gem"
+   ]
+  },
+  {
+   "word": "carreteiro",
+   "syllables": [
+    "car",
+    "re",
+    "tei",
+    "ro"
+   ]
+  },
+  {
+   "word": "golfar",
+   "syllables": [
+    "gol",
+    "far"
+   ]
+  },
+  {
+   "word": "ganga",
+   "syllables": [
+    "gan",
+    "ga"
+   ]
+  },
+  {
+   "word": "contralto",
+   "syllables": [
+    "con",
+    "tral",
+    "to"
+   ]
+  },
+  {
+   "word": "monoteísta",
+   "syllables": [
+    "mo",
+    "no",
+    "te",
+    "ís",
+    "ta"
+   ]
+  },
+  {
+   "word": "jarrinha",
+   "syllables": [
+    "jar",
+    "ri",
+    "nha"
+   ]
+  },
+  {
+   "word": "herege",
+   "syllables": [
+    "he",
+    "re",
+    "ge"
+   ]
+  },
+  {
+   "word": "dramaticidade",
+   "syllables": [
+    "dra",
+    "ma",
+    "ti",
+    "ci",
+    "da",
+    "de"
+   ]
+  },
+  {
+   "word": "pedraria",
+   "syllables": [
+    "pe",
+    "dra",
+    "ri",
+    "a"
+   ]
+  },
+  {
+   "word": "genesíaco",
+   "syllables": [
+    "ge",
+    "ne",
+    "sí",
+    "a",
+    "co"
+   ]
+  },
+  {
+   "word": "casamento",
+   "syllables": [
+    "ca",
+    "sa",
+    "men",
+    "to"
+   ]
+  },
+  {
+   "word": "recortador",
+   "syllables": [
+    "re",
+    "cor",
+    "ta",
+    "dor"
+   ]
+  },
+  {
+   "word": "arredor",
+   "syllables": [
+    "ar",
+    "re",
+    "dor"
+   ]
+  },
+  {
+   "word": "proceder",
+   "syllables": [
+    "pro",
+    "ce",
+    "der"
+   ]
+  },
+  {
+   "word": "estelar",
+   "syllables": [
+    "es",
+    "te",
+    "lar"
+   ]
+  },
+  {
+   "word": "digressão",
+   "syllables": [
+    "di",
+    "gres",
+    "são"
+   ]
+  },
+  {
+   "word": "plantio",
+   "syllables": [
+    "plan",
+    "ti",
+    "o"
+   ]
+  },
+  {
+   "word": "diacrónico",
+   "syllables": [
+    "di",
+    "a",
+    "cró",
+    "ni",
+    "co"
+   ]
+  },
+  {
+   "word": "desarrufo",
+   "syllables": [
+    "de",
+    "sar",
+    "ru",
+    "fo"
+   ]
+  },
+  {
+   "word": "orientar",
+   "syllables": [
+    "o",
+    "ri",
+    "en",
+    "tar"
+   ]
+  },
+  {
+   "word": "rimance",
+   "syllables": [
+    "ri",
+    "man",
+    "ce"
+   ]
+  },
+  {
+   "word": "pedral",
+   "syllables": [
+    "pe",
+    "dral"
+   ]
+  },
+  {
+   "word": "corvina",
+   "syllables": [
+    "cor",
+    "vi",
+    "na"
+   ]
+  },
+  {
+   "word": "volframite",
+   "syllables": [
+    "vol",
+    "fra",
+    "mi",
+    "te"
+   ]
+  },
+  {
+   "word": "ajuntador",
+   "syllables": [
+    "a",
+    "jun",
+    "ta",
+    "dor"
+   ]
+  },
+  {
+   "word": "amigo",
+   "syllables": [
+    "a",
+    "mi",
+    "go"
+   ]
+  },
+  {
+   "word": "globalista",
+   "syllables": [
+    "glo",
+    "ba",
+    "lis",
+    "ta"
+   ]
+  },
+  {
+   "word": "beringela",
+   "syllables": [
+    "be",
+    "rin",
+    "ge",
+    "la"
+   ]
+  },
+  {
+   "word": "avião",
+   "syllables": [
+    "a",
+    "vi",
+    "ão"
+   ]
+  },
+  {
+   "word": "coutar",
+   "syllables": [
+    "cou",
+    "tar"
+   ]
+  },
+  {
+   "word": "reabsorvível",
+   "syllables": [
+    "re",
+    "ab",
+    "sor",
+    "ví",
+    "vel"
+   ]
+  },
+  {
+   "word": "cedinho",
+   "syllables": [
+    "ce",
+    "di",
+    "nho"
+   ]
+  },
+  {
+   "word": "serrano",
+   "syllables": [
+    "ser",
+    "ra",
+    "no"
+   ]
+  },
+  {
+   "word": "arrifana",
+   "syllables": [
+    "ar",
+    "ri",
+    "fa",
+    "na"
+   ]
+  },
+  {
+   "word": "voluntário",
+   "syllables": [
+    "vo",
+    "lun",
+    "tá",
+    "ri",
+    "o"
+   ]
+  },
+  {
+   "word": "amblíope",
+   "syllables": [
+    "am",
+    "blí",
+    "o",
+    "pe"
+   ]
+  },
+  {
+   "word": "antipelicular",
+   "syllables": [
+    "an",
+    "ti",
+    "pe",
+    "li",
+    "cu",
+    "lar"
+   ]
+  },
+  {
+   "word": "depurado",
+   "syllables": [
+    "de",
+    "pu",
+    "ra",
+    "do"
+   ]
+  },
+  {
+   "word": "frescura",
+   "syllables": [
+    "fres",
+    "cu",
+    "ra"
+   ]
+  },
+  {
+   "word": "equalizador",
+   "syllables": [
+    "e",
+    "qua",
+    "li",
+    "za",
+    "dor"
+   ]
+  },
+  {
+   "word": "fotocopiar",
+   "syllables": [
+    "fo",
+    "to",
+    "co",
+    "pi",
+    "ar"
+   ]
+  },
+  {
+   "word": "decência",
+   "syllables": [
+    "de",
+    "cên",
+    "ci",
+    "a"
+   ]
+  },
+  {
+   "word": "cipo",
+   "syllables": [
+    "ci",
+    "po"
+   ]
+  },
+  {
+   "word": "equilíbrio",
+   "syllables": [
+    "e",
+    "qui",
+    "lí",
+    "bri",
+    "o"
+   ]
+  },
+  {
+   "word": "carregar",
+   "syllables": [
+    "car",
+    "re",
+    "gar"
+   ]
+  },
+  {
+   "word": "despela",
+   "syllables": [
+    "des",
+    "pe",
+    "la"
+   ]
+  },
+  {
+   "word": "prerromper",
+   "syllables": [
+    "prer",
+    "rom",
+    "per"
+   ]
+  },
+  {
+   "word": "dianético",
+   "syllables": [
+    "di",
+    "a",
+    "né",
+    "ti",
+    "co"
+   ]
+  },
+  {
+   "word": "desimplicar",
+   "syllables": [
+    "de",
+    "sim",
+    "pli",
+    "car"
+   ]
+  },
+  {
+   "word": "desacobardar",
+   "syllables": [
+    "de",
+    "sa",
+    "co",
+    "bar",
+    "dar"
+   ]
+  },
+  {
+   "word": "encaixotado",
+   "syllables": [
+    "en",
+    "cai",
+    "xo",
+    "ta",
+    "do"
+   ]
+  },
+  {
+   "word": "sumidouro",
+   "syllables": [
+    "su",
+    "mi",
+    "dou",
+    "ro"
+   ]
+  },
+  {
+   "word": "desagradecimento",
+   "syllables": [
+    "de",
+    "sa",
+    "gra",
+    "de",
+    "ci",
+    "men",
+    "to"
+   ]
+  },
+  {
+   "word": "abastado",
+   "syllables": [
+    "a",
+    "bas",
+    "ta",
+    "do"
+   ]
+  },
+  {
+   "word": "inadequado",
+   "syllables": [
+    "i",
+    "na",
+    "de",
+    "qua",
+    "do"
+   ]
+  },
+  {
+   "word": "congelamento",
+   "syllables": [
+    "con",
+    "ge",
+    "la",
+    "men",
+    "to"
+   ]
+  },
+  {
+   "word": "psicossomatismo",
+   "syllables": [
+    "psi",
+    "cos",
+    "so",
+    "ma",
+    "tis",
+    "mo"
+   ]
+  },
+  {
+   "word": "campina",
+   "syllables": [
+    "cam",
+    "pi",
+    "na"
+   ]
+  },
+  {
+   "word": "bíblia",
+   "syllables": [
+    "bí",
+    "bli",
+    "a"
+   ]
+  },
+  {
+   "word": "esfericidade",
+   "syllables": [
+    "es",
+    "fe",
+    "ri",
+    "ci",
+    "da",
+    "de"
+   ]
+  },
+  {
+   "word": "siglar",
+   "syllables": [
+    "si",
+    "glar"
+   ]
+  },
+  {
+   "word": "impelir",
+   "syllables": [
+    "im",
+    "pe",
+    "lir"
+   ]
+  },
+  {
+   "word": "enduro",
+   "syllables": [
+    "en",
+    "du",
+    "ro"
+   ]
+  },
+  {
+   "word": "rabejar",
+   "syllables": [
+    "ra",
+    "be",
+    "jar"
+   ]
+  },
+  {
+   "word": "pedregulho",
+   "syllables": [
+    "pe",
+    "dre",
+    "gu",
+    "lho"
+   ]
+  },
+  {
+   "word": "desconcertado",
+   "syllables": [
+    "des",
+    "con",
+    "cer",
+    "ta",
+    "do"
+   ]
+  },
+  {
+   "word": "melopeia",
+   "syllables": [
+    "me",
+    "lo",
+    "pei",
+    "a"
+   ]
+  },
+  {
+   "word": "perigo",
+   "syllables": [
+    "pe",
+    "ri",
+    "go"
+   ]
+  },
+  {
+   "word": "afinação",
+   "syllables": [
+    "a",
+    "fi",
+    "na",
+    "ção"
+   ]
+  },
+  {
+   "word": "cadaval",
+   "syllables": [
+    "ca",
+    "da",
+    "val"
+   ]
+  },
+  {
+   "word": "pouquinho",
+   "syllables": [
+    "pou",
+    "qui",
+    "nho"
+   ]
+  },
+  {
+   "word": "abcesso",
+   "syllables": [
+    "ab",
+    "ces",
+    "so"
+   ]
+  },
+  {
+   "word": "batotar",
+   "syllables": [
+    "ba",
+    "to",
+    "tar"
+   ]
+  },
+  {
+   "word": "assoprar",
+   "syllables": [
+    "as",
+    "so",
+    "prar"
+   ]
+  },
+  {
+   "word": "ajanotar",
+   "syllables": [
+    "a",
+    "ja",
+    "no",
+    "tar"
+   ]
+  },
+  {
+   "word": "exato",
+   "syllables": [
+    "e",
+    "xa",
+    "to"
+   ]
+  },
+  {
+   "word": "polir",
+   "syllables": [
+    "po",
+    "lir"
+   ]
+  },
+  {
+   "word": "viação",
+   "syllables": [
+    "vi",
+    "a",
+    "ção"
+   ]
+  },
+  {
+   "word": "pelame",
+   "syllables": [
+    "pe",
+    "la",
+    "me"
+   ]
+  },
+  {
+   "word": "recobrável",
+   "syllables": [
+    "re",
+    "co",
+    "brá",
+    "vel"
+   ]
+  },
+  {
+   "word": "conservação",
+   "syllables": [
+    "con",
+    "ser",
+    "va",
+    "ção"
+   ]
+  },
+  {
+   "word": "fisiatria",
+   "syllables": [
+    "fi",
+    "si",
+    "a",
+    "tri",
+    "a"
+   ]
+  },
+  {
+   "word": "alcatear",
+   "syllables": [
+    "al",
+    "ca",
+    "te",
+    "ar"
+   ]
+  },
+  {
+   "word": "concentracionário",
+   "syllables": [
+    "con",
+    "cen",
+    "tra",
+    "ci",
+    "o",
+    "ná",
+    "ri",
+    "o"
+   ]
+  },
+  {
+   "word": "incinerado",
+   "syllables": [
+    "in",
+    "ci",
+    "ne",
+    "ra",
+    "do"
+   ]
+  },
+  {
+   "word": "fontana",
+   "syllables": [
+    "fon",
+    "ta",
+    "na"
+   ]
+  },
+  {
+   "word": "caribe",
+   "syllables": [
+    "ca",
+    "ri",
+    "be"
+   ]
+  },
+  {
+   "word": "injunção",
+   "syllables": [
+    "in",
+    "jun",
+    "ção"
+   ]
+  },
+  {
+   "word": "laminação",
+   "syllables": [
+    "la",
+    "mi",
+    "na",
+    "ção"
+   ]
+  },
+  {
+   "word": "descoagulação",
+   "syllables": [
+    "des",
+    "co",
+    "a",
+    "gu",
+    "la",
+    "ção"
+   ]
+  },
+  {
+   "word": "fogaréu",
+   "syllables": [
+    "fo",
+    "ga",
+    "réu"
+   ]
+  },
+  {
+   "word": "torrado",
+   "syllables": [
+    "tor",
+    "ra",
+    "do"
+   ]
+  },
+  {
+   "word": "redoma",
+   "syllables": [
+    "re",
+    "do",
+    "ma"
+   ]
+  },
+  {
+   "word": "tomar",
+   "syllables": [
+    "to",
+    "mar"
+   ]
+  },
+  {
+   "word": "montanhês",
+   "syllables": [
+    "mon",
+    "ta",
+    "nhês"
+   ]
+  },
+  {
+   "word": "autonomizar",
+   "syllables": [
+    "au",
+    "to",
+    "no",
+    "mi",
+    "zar"
+   ]
+  },
+  {
+   "word": "acabamento",
+   "syllables": [
+    "a",
+    "ca",
+    "ba",
+    "men",
+    "to"
+   ]
+  },
+  {
+   "word": "zinco",
+   "syllables": [
+    "zin",
+    "co"
+   ]
+  },
+  {
+   "word": "certificar",
+   "syllables": [
+    "cer",
+    "ti",
+    "fi",
+    "car"
+   ]
+  },
+  {
+   "word": "antiar",
+   "syllables": [
+    "an",
+    "ti",
+    "ar"
+   ]
+  },
+  {
+   "word": "contratação",
+   "syllables": [
+    "con",
+    "tra",
+    "ta",
+    "ção"
+   ]
+  },
+  {
+   "word": "acessivelmente",
+   "syllables": [
+    "a",
+    "ces",
+    "si",
+    "vel",
+    "men",
+    "te"
+   ]
+  },
+  {
+   "word": "marafona",
+   "syllables": [
+    "ma",
+    "ra",
+    "fo",
+    "na"
+   ]
+  },
+  {
+   "word": "categoria",
+   "syllables": [
+    "ca",
+    "te",
+    "go",
+    "ri",
+    "a"
+   ]
+  },
+  {
+   "word": "compensador",
+   "syllables": [
+    "com",
+    "pen",
+    "sa",
+    "dor"
+   ]
+  },
+  {
+   "word": "adocicado",
+   "syllables": [
+    "a",
+    "do",
+    "ci",
+    "ca",
+    "do"
+   ]
+  },
+  {
+   "word": "enxovalhado",
+   "syllables": [
+    "en",
+    "xo",
+    "va",
+    "lha",
+    "do"
+   ]
+  },
+  {
+   "word": "articulação",
+   "syllables": [
+    "ar",
+    "ti",
+    "cu",
+    "la",
+    "ção"
+   ]
+  },
+  {
+   "word": "grandíssimo",
+   "syllables": [
+    "gran",
+    "dís",
+    "si",
+    "mo"
+   ]
+  },
+  {
+   "word": "gracioso",
+   "syllables": [
+    "gra",
+    "ci",
+    "o",
+    "so"
+   ]
+  },
+  {
+   "word": "passiva",
+   "syllables": [
+    "pas",
+    "si",
+    "va"
+   ]
+  },
+  {
+   "word": "bolha",
+   "syllables": [
+    "bo",
+    "lha"
+   ]
+  },
+  {
+   "word": "pegão",
+   "syllables": [
+    "pe",
+    "gão"
+   ]
+  },
+  {
+   "word": "expeditivo",
+   "syllables": [
+    "ex",
+    "pe",
+    "di",
+    "ti",
+    "vo"
+   ]
+  },
+  {
+   "word": "terapeuta",
+   "syllables": [
+    "te",
+    "ra",
+    "peu",
+    "ta"
+   ]
+  },
+  {
+   "word": "nó",
+   "syllables": [
+    "nó"
+   ]
+  },
+  {
+   "word": "indeterminador",
+   "syllables": [
+    "in",
+    "de",
+    "ter",
+    "mi",
+    "na",
+    "dor"
+   ]
+  },
+  {
+   "word": "orbital",
+   "syllables": [
+    "or",
+    "bi",
+    "tal"
+   ]
+  },
+  {
+   "word": "coadministrador",
+   "syllables": [
+    "co",
+    "ad",
+    "mi",
+    "nis",
+    "tra",
+    "dor"
+   ]
+  },
+  {
+   "word": "trincadela",
+   "syllables": [
+    "trin",
+    "ca",
+    "de",
+    "la"
+   ]
+  },
+  {
+   "word": "telecopiador",
+   "syllables": [
+    "te",
+    "le",
+    "co",
+    "pi",
+    "a",
+    "dor"
+   ]
+  },
+  {
+   "word": "avençar",
+   "syllables": [
+    "a",
+    "ven",
+    "çar"
+   ]
+  },
+  {
+   "word": "aforismo",
+   "syllables": [
+    "a",
+    "fo",
+    "ris",
+    "mo"
+   ]
+  },
+  {
+   "word": "coiote",
+   "syllables": [
+    "coi",
+    "o",
+    "te"
+   ]
+  },
+  {
+   "word": "desabordar",
+   "syllables": [
+    "de",
+    "sa",
+    "bor",
+    "dar"
+   ]
+  },
+  {
+   "word": "designação",
+   "syllables": [
+    "de",
+    "sig",
+    "na",
+    "ção"
+   ]
+  },
+  {
+   "word": "episodiar",
+   "syllables": [
+    "e",
+    "pi",
+    "so",
+    "di",
+    "ar"
+   ]
+  },
+  {
+   "word": "espalhafatar",
+   "syllables": [
+    "es",
+    "pa",
+    "lha",
+    "fa",
+    "tar"
+   ]
+  },
+  {
+   "word": "feeria",
+   "syllables": [
+    "fe",
+    "e",
+    "ri",
+    "a"
+   ]
+  },
+  {
+   "word": "parido",
+   "syllables": [
+    "pa",
+    "ri",
+    "do"
+   ]
+  },
+  {
+   "word": "computadorizado",
+   "syllables": [
+    "com",
+    "pu",
+    "ta",
+    "do",
+    "ri",
+    "za",
+    "do"
+   ]
+  },
+  {
+   "word": "palanque",
+   "syllables": [
+    "pa",
+    "lan",
+    "que"
+   ]
+  },
+  {
+   "word": "aleijão",
+   "syllables": [
+    "a",
+    "lei",
+    "jão"
+   ]
+  },
+  {
+   "word": "siba",
+   "syllables": [
+    "si",
+    "ba"
+   ]
+  },
+  {
+   "word": "chorrilhar",
+   "syllables": [
+    "chor",
+    "ri",
+    "lhar"
+   ]
+  },
+  {
+   "word": "basear",
+   "syllables": [
+    "ba",
+    "se",
+    "ar"
+   ]
+  },
+  {
+   "word": "fiandeira",
+   "syllables": [
+    "fi",
+    "an",
+    "dei",
+    "ra"
+   ]
+  },
+  {
+   "word": "engate",
+   "syllables": [
+    "en",
+    "ga",
+    "te"
+   ]
+  },
+  {
+   "word": "inibição",
+   "syllables": [
+    "i",
+    "ni",
+    "bi",
+    "ção"
+   ]
+  },
+  {
+   "word": "emergir",
+   "syllables": [
+    "e",
+    "mer",
+    "gir"
+   ]
+  },
+  {
+   "word": "mármore",
+   "syllables": [
+    "már",
+    "mo",
+    "re"
+   ]
+  },
+  {
+   "word": "apertão",
+   "syllables": [
+    "a",
+    "per",
+    "tão"
+   ]
+  },
+  {
+   "word": "desassanhar",
+   "syllables": [
+    "de",
+    "sas",
+    "sa",
+    "nhar"
+   ]
+  },
+  {
+   "word": "flavor",
+   "syllables": [
+    "fla",
+    "vor"
+   ]
+  },
+  {
+   "word": "descolorido",
+   "syllables": [
+    "des",
+    "co",
+    "lo",
+    "ri",
+    "do"
+   ]
+  },
+  {
+   "word": "camone",
+   "syllables": [
+    "ca",
+    "mo",
+    "ne"
+   ]
+  },
+  {
+   "word": "predileto",
+   "syllables": [
+    "pre",
+    "di",
+    "le",
+    "to"
+   ]
+  },
+  {
+   "word": "ininterrompido",
+   "syllables": [
+    "i",
+    "nin",
+    "ter",
+    "rom",
+    "pi",
+    "do"
+   ]
+  },
+  {
+   "word": "pragana",
+   "syllables": [
+    "pra",
+    "ga",
+    "na"
+   ]
+  },
+  {
+   "word": "relego",
+   "syllables": [
+    "re",
+    "le",
+    "go"
+   ]
+  },
+  {
+   "word": "rebotar",
+   "syllables": [
+    "re",
+    "bo",
+    "tar"
+   ]
+  },
+  {
+   "word": "arrebentar",
+   "syllables": [
+    "ar",
+    "re",
+    "ben",
+    "tar"
+   ]
+  },
+  {
+   "word": "consolidado",
+   "syllables": [
+    "con",
+    "so",
+    "li",
+    "da",
+    "do"
+   ]
+  },
+  {
+   "word": "antecedente",
+   "syllables": [
+    "an",
+    "te",
+    "ce",
+    "den",
+    "te"
+   ]
+  },
+  {
+   "word": "irrespirabilidade",
+   "syllables": [
+    "ir",
+    "res",
+    "pi",
+    "ra",
+    "bi",
+    "li",
+    "da",
+    "de"
+   ]
+  },
+  {
+   "word": "consciente",
+   "syllables": [
+    "cons",
+    "ci",
+    "en",
+    "te"
+   ]
+  },
+  {
+   "word": "antipolítico",
+   "syllables": [
+    "an",
+    "ti",
+    "po",
+    "lí",
+    "ti",
+    "co"
+   ]
+  },
+  {
+   "word": "audácia",
+   "syllables": [
+    "au",
+    "dá",
+    "ci",
+    "a"
+   ]
+  },
+  {
+   "word": "maiato",
+   "syllables": [
+    "mai",
+    "a",
+    "to"
+   ]
+  },
+  {
+   "word": "alabardar",
+   "syllables": [
+    "a",
+    "la",
+    "bar",
+    "dar"
+   ]
+  },
+  {
+   "word": "avençado",
+   "syllables": [
+    "a",
+    "ven",
+    "ça",
+    "do"
+   ]
+  },
+  {
+   "word": "conjuntivite",
+   "syllables": [
+    "con",
+    "jun",
+    "ti",
+    "vi",
+    "te"
+   ]
+  },
+  {
+   "word": "abalienação",
+   "syllables": [
+    "a",
+    "ba",
+    "li",
+    "e",
+    "na",
+    "ção"
+   ]
+  },
+  {
+   "word": "neblina",
+   "syllables": [
+    "ne",
+    "bli",
+    "na"
+   ]
+  },
+  {
+   "word": "iniquamente",
+   "syllables": [
+    "i",
+    "ni",
+    "qua",
+    "men",
+    "te"
+   ]
+  },
+  {
+   "word": "fisga",
+   "syllables": [
+    "fis",
+    "ga"
+   ]
+  },
+  {
+   "word": "descaída",
+   "syllables": [
+    "des",
+    "ca",
+    "í",
+    "da"
+   ]
+  },
+  {
+   "word": "riscada",
+   "syllables": [
+    "ris",
+    "ca",
+    "da"
+   ]
+  },
+  {
+   "word": "mando",
+   "syllables": [
+    "man",
+    "do"
+   ]
+  },
+  {
+   "word": "desconceito",
+   "syllables": [
+    "des",
+    "con",
+    "cei",
+    "to"
+   ]
+  },
+  {
+   "word": "antiterrorista",
+   "syllables": [
+    "an",
+    "ti",
+    "ter",
+    "ro",
+    "ris",
+    "ta"
+   ]
+  },
+  {
+   "word": "constrangido",
+   "syllables": [
+    "cons",
+    "tran",
+    "gi",
+    "do"
+   ]
+  },
+  {
+   "word": "microclimático",
+   "syllables": [
+    "mi",
+    "cro",
+    "cli",
+    "má",
+    "ti",
+    "co"
+   ]
+  },
+  {
+   "word": "mexilhoeira",
+   "syllables": [
+    "me",
+    "xi",
+    "lho",
+    "ei",
+    "ra"
+   ]
+  },
+  {
+   "word": "batávico",
+   "syllables": [
+    "ba",
+    "tá",
+    "vi",
+    "co"
+   ]
+  },
+  {
+   "word": "imolado",
+   "syllables": [
+    "i",
+    "mo",
+    "la",
+    "do"
+   ]
+  },
+  {
+   "word": "atabalhoadamente",
+   "syllables": [
+    "a",
+    "ta",
+    "ba",
+    "lho",
+    "a",
+    "da",
+    "men",
+    "te"
+   ]
+  },
+  {
+   "word": "foder",
+   "syllables": [
+    "fo",
+    "der"
+   ]
+  },
+  {
+   "word": "hiparco",
+   "syllables": [
+    "hi",
+    "par",
+    "co"
+   ]
+  },
+  {
+   "word": "male",
+   "syllables": [
+    "ma",
+    "le"
+   ]
+  },
+  {
+   "word": "insuperável",
+   "syllables": [
+    "in",
+    "su",
+    "pe",
+    "rá",
+    "vel"
+   ]
+  },
+  {
+   "word": "cinzelado",
+   "syllables": [
+    "cin",
+    "ze",
+    "la",
+    "do"
+   ]
+  },
+  {
+   "word": "bitoque",
+   "syllables": [
+    "bi",
+    "to",
+    "que"
+   ]
+  },
+  {
+   "word": "historial",
+   "syllables": [
+    "his",
+    "to",
+    "ri",
+    "al"
+   ]
+  },
+  {
+   "word": "participar",
+   "syllables": [
+    "par",
+    "ti",
+    "ci",
+    "par"
+   ]
+  },
+  {
+   "word": "transitoriedade",
+   "syllables": [
+    "tran",
+    "si",
+    "to",
+    "ri",
+    "e",
+    "da",
+    "de"
+   ]
+  },
+  {
+   "word": "tolerar",
+   "syllables": [
+    "to",
+    "le",
+    "rar"
+   ]
+  },
+  {
+   "word": "implícito",
+   "syllables": [
+    "im",
+    "plí",
+    "ci",
+    "to"
+   ]
+  },
+  {
+   "word": "intuicionista",
+   "syllables": [
+    "in",
+    "tu",
+    "i",
+    "ci",
+    "o",
+    "nis",
+    "ta"
+   ]
+  },
+  {
+   "word": "adenda",
+   "syllables": [
+    "a",
+    "den",
+    "da"
+   ]
+  },
+  {
+   "word": "delambido",
+   "syllables": [
+    "de",
+    "lam",
+    "bi",
+    "do"
+   ]
+  },
+  {
+   "word": "poente",
+   "syllables": [
+    "po",
+    "en",
+    "te"
+   ]
+  },
+  {
+   "word": "austrálio",
+   "syllables": [
+    "aus",
+    "trá",
+    "li",
+    "o"
+   ]
+  },
+  {
+   "word": "enxergar",
+   "syllables": [
+    "en",
+    "xer",
+    "gar"
+   ]
+  },
+  {
+   "word": "espiritualista",
+   "syllables": [
+    "es",
+    "pi",
+    "ri",
+    "tu",
+    "a",
+    "lis",
+    "ta"
+   ]
+  },
+  {
+   "word": "refilar",
+   "syllables": [
+    "re",
+    "fi",
+    "lar"
+   ]
+  },
+  {
+   "word": "frangir",
+   "syllables": [
+    "fran",
+    "gir"
+   ]
+  },
+  {
+   "word": "pantera",
+   "syllables": [
+    "pan",
+    "te",
+    "ra"
+   ]
+  },
+  {
+   "word": "fermentação",
+   "syllables": [
+    "fer",
+    "men",
+    "ta",
+    "ção"
+   ]
+  },
+  {
+   "word": "conclusão",
+   "syllables": [
+    "con",
+    "clu",
+    "são"
+   ]
+  },
+  {
+   "word": "perdido",
+   "syllables": [
+    "per",
+    "di",
+    "do"
+   ]
+  },
+  {
+   "word": "alpinismo",
+   "syllables": [
+    "al",
+    "pi",
+    "nis",
+    "mo"
+   ]
+  },
+  {
+   "word": "fungibilidade",
+   "syllables": [
+    "fun",
+    "gi",
+    "bi",
+    "li",
+    "da",
+    "de"
+   ]
+  },
+  {
+   "word": "obra",
+   "syllables": [
+    "o",
+    "bra"
+   ]
+  },
+  {
+   "word": "computacional",
+   "syllables": [
+    "com",
+    "pu",
+    "ta",
+    "ci",
+    "o",
+    "nal"
+   ]
+  },
+  {
+   "word": "ossário",
+   "syllables": [
+    "os",
+    "sá",
+    "ri",
+    "o"
+   ]
+  },
+  {
+   "word": "canejo",
+   "syllables": [
+    "ca",
+    "ne",
+    "jo"
+   ]
+  },
+  {
+   "word": "fotossíntese",
+   "syllables": [
+    "fo",
+    "tos",
+    "sín",
+    "te",
+    "se"
+   ]
+  },
+  {
+   "word": "contrariado",
+   "syllables": [
+    "con",
+    "tra",
+    "ri",
+    "a",
+    "do"
+   ]
+  },
+  {
+   "word": "palmado",
+   "syllables": [
+    "pal",
+    "ma",
+    "do"
+   ]
+  },
+  {
+   "word": "bosse",
+   "syllables": [
+    "bos",
+    "se"
+   ]
+  },
+  {
+   "word": "suco",
+   "syllables": [
+    "su",
+    "co"
+   ]
+  },
+  {
+   "word": "ritmicamente",
+   "syllables": [
+    "rit",
+    "mi",
+    "ca",
+    "men",
+    "te"
+   ]
+  },
+  {
+   "word": "ampola",
+   "syllables": [
+    "am",
+    "po",
+    "la"
+   ]
+  },
+  {
+   "word": "pregnância",
+   "syllables": [
+    "preg",
+    "nân",
+    "ci",
+    "a"
+   ]
+  },
+  {
+   "word": "fajardo",
+   "syllables": [
+    "fa",
+    "jar",
+    "do"
+   ]
+  },
+  {
+   "word": "arrevesado",
+   "syllables": [
+    "ar",
+    "re",
+    "ve",
+    "sa",
+    "do"
+   ]
+  },
+  {
+   "word": "federalismo",
+   "syllables": [
+    "fe",
+    "de",
+    "ra",
+    "lis",
+    "mo"
+   ]
+  },
+  {
+   "word": "acrisolar",
+   "syllables": [
+    "a",
+    "cri",
+    "so",
+    "lar"
+   ]
+  },
+  {
+   "word": "inquisidor",
+   "syllables": [
+    "in",
+    "qui",
+    "si",
+    "dor"
+   ]
+  },
+  {
+   "word": "determinar",
+   "syllables": [
+    "de",
+    "ter",
+    "mi",
+    "nar"
+   ]
+  },
+  {
+   "word": "galega",
+   "syllables": [
+    "ga",
+    "le",
+    "ga"
+   ]
+  },
+  {
+   "word": "inalado",
+   "syllables": [
+    "i",
+    "na",
+    "la",
+    "do"
+   ]
+  },
+  {
+   "word": "expropriação",
+   "syllables": [
+    "ex",
+    "pro",
+    "pri",
+    "a",
+    "ção"
+   ]
+  },
+  {
+   "word": "manchado",
+   "syllables": [
+    "man",
+    "cha",
+    "do"
+   ]
+  },
+  {
+   "word": "indiferente",
+   "syllables": [
+    "in",
+    "di",
+    "fe",
+    "ren",
+    "te"
+   ]
+  },
+  {
+   "word": "amovível",
+   "syllables": [
+    "a",
+    "mo",
+    "ví",
+    "vel"
+   ]
+  },
+  {
+   "word": "desinquietante",
+   "syllables": [
+    "de",
+    "sin",
+    "qui",
+    "e",
+    "tan",
+    "te"
+   ]
+  },
+  {
+   "word": "hierarquizar",
+   "syllables": [
+    "hi",
+    "e",
+    "rar",
+    "qui",
+    "zar"
+   ]
+  },
+  {
+   "word": "latejar",
+   "syllables": [
+    "la",
+    "te",
+    "jar"
+   ]
+  },
+  {
+   "word": "mexida",
+   "syllables": [
+    "me",
+    "xi",
+    "da"
+   ]
+  },
+  {
+   "word": "palmo",
+   "syllables": [
+    "pal",
+    "mo"
+   ]
+  },
+  {
+   "word": "pedinchar",
+   "syllables": [
+    "pe",
+    "din",
+    "char"
+   ]
+  },
+  {
+   "word": "granir",
+   "syllables": [
+    "gra",
+    "nir"
+   ]
+  },
+  {
+   "word": "invocável",
+   "syllables": [
+    "in",
+    "vo",
+    "cá",
+    "vel"
+   ]
+  },
+  {
+   "word": "lesão",
+   "syllables": [
+    "le",
+    "são"
+   ]
+  },
+  {
+   "word": "eletrofisiológico",
+   "syllables": [
+    "e",
+    "le",
+    "tro",
+    "fi",
+    "si",
+    "o",
+    "ló",
+    "gi",
+    "co"
+   ]
+  },
+  {
+   "word": "festejar",
+   "syllables": [
+    "fes",
+    "te",
+    "jar"
+   ]
+  },
+  {
+   "word": "detenção",
+   "syllables": [
+    "de",
+    "ten",
+    "ção"
+   ]
+  },
+  {
+   "word": "inenarrável",
+   "syllables": [
+    "i",
+    "ne",
+    "nar",
+    "rá",
+    "vel"
+   ]
+  },
+  {
+   "word": "tareia",
+   "syllables": [
+    "ta",
+    "rei",
+    "a"
+   ]
+  },
+  {
+   "word": "eutanásia",
+   "syllables": [
+    "eu",
+    "ta",
+    "ná",
+    "si",
+    "a"
+   ]
+  },
+  {
+   "word": "astracã",
+   "syllables": [
+    "as",
+    "tra",
+    "cã"
+   ]
+  },
+  {
+   "word": "vedro",
+   "syllables": [
+    "ve",
+    "dro"
+   ]
+  },
+  {
+   "word": "farrar",
+   "syllables": [
+    "far",
+    "rar"
+   ]
+  },
+  {
+   "word": "excecional",
+   "syllables": [
+    "ex",
+    "ce",
+    "ci",
+    "o",
+    "nal"
+   ]
+  },
+  {
+   "word": "pinote",
+   "syllables": [
+    "pi",
+    "no",
+    "te"
+   ]
+  },
+  {
+   "word": "mercador",
+   "syllables": [
+    "mer",
+    "ca",
+    "dor"
+   ]
+  },
+  {
+   "word": "filamento",
+   "syllables": [
+    "fi",
+    "la",
+    "men",
+    "to"
+   ]
+  },
+  {
+   "word": "boça",
+   "syllables": [
+    "bo",
+    "ça"
+   ]
+  },
+  {
+   "word": "desnorteamento",
+   "syllables": [
+    "des",
+    "nor",
+    "te",
+    "a",
+    "men",
+    "to"
+   ]
+  },
+  {
+   "word": "nazi",
+   "syllables": [
+    "na",
+    "zi"
+   ]
+  },
+  {
+   "word": "bica",
+   "syllables": [
+    "bi",
+    "ca"
+   ]
+  },
+  {
+   "word": "afónico",
+   "syllables": [
+    "a",
+    "fó",
+    "ni",
+    "co"
+   ]
+  },
+  {
+   "word": "gaza",
+   "syllables": [
+    "ga",
+    "za"
+   ]
+  },
+  {
+   "word": "desamolgar",
+   "syllables": [
+    "de",
+    "sa",
+    "mol",
+    "gar"
+   ]
+  },
+  {
+   "word": "sacerdócio",
+   "syllables": [
+    "sa",
+    "cer",
+    "dó",
+    "ci",
+    "o"
+   ]
+  },
+  {
+   "word": "dopado",
+   "syllables": [
+    "do",
+    "pa",
+    "do"
+   ]
+  },
+  {
+   "word": "confortavelmente",
+   "syllables": [
+    "con",
+    "for",
+    "ta",
+    "vel",
+    "men",
+    "te"
+   ]
+  },
+  {
+   "word": "supletivo",
+   "syllables": [
+    "su",
+    "ple",
+    "ti",
+    "vo"
+   ]
+  },
+  {
+   "word": "cataclísmico",
+   "syllables": [
+    "ca",
+    "ta",
+    "clís",
+    "mi",
+    "co"
+   ]
+  },
+  {
+   "word": "achincalhamento",
+   "syllables": [
+    "a",
+    "chin",
+    "ca",
+    "lha",
+    "men",
+    "to"
+   ]
+  },
+  {
+   "word": "âncora",
+   "syllables": [
+    "ân",
+    "co",
+    "ra"
+   ]
+  },
+  {
+   "word": "vigília",
+   "syllables": [
+    "vi",
+    "gí",
+    "li",
+    "a"
+   ]
+  },
+  {
+   "word": "desarquear",
+   "syllables": [
+    "de",
+    "sar",
+    "que",
+    "ar"
+   ]
+  },
+  {
+   "word": "adubado",
+   "syllables": [
+    "a",
+    "du",
+    "ba",
+    "do"
+   ]
+  },
+  {
+   "word": "frágil",
+   "syllables": [
+    "frá",
+    "gil"
+   ]
+  },
+  {
+   "word": "atracão",
+   "syllables": [
+    "a",
+    "tra",
+    "cão"
+   ]
+  },
+  {
+   "word": "obreiro",
+   "syllables": [
+    "o",
+    "brei",
+    "ro"
+   ]
+  },
+  {
+   "word": "esvanecer",
+   "syllables": [
+    "es",
+    "va",
+    "ne",
+    "cer"
+   ]
+  },
+  {
+   "word": "delfim",
+   "syllables": [
+    "del",
+    "fim"
+   ]
+  },
+  {
+   "word": "lenitivo",
+   "syllables": [
+    "le",
+    "ni",
+    "ti",
+    "vo"
+   ]
+  },
+  {
+   "word": "falhanço",
+   "syllables": [
+    "fa",
+    "lhan",
+    "ço"
+   ]
+  }
+ ]
 }

--- a/tests/test_accuracy_regression.py
+++ b/tests/test_accuracy_regression.py
@@ -1,17 +1,18 @@
 """Accuracy regression guard for the rule-based syllabifier.
 
-Promotes the notebook benchmark to CI. The bundled gold sample
-(`tests/gold_sample.json`) is a 500-entry deterministic draw from the
-`TigreGotico/portuguese_phonetic_lexicon` dataset (region ``lbx``), so the
-check runs offline with no dataset download. A regression in the rules drops
-the match rate and fails the test.
+The bundled gold sample (``tests/gold_sample.json``) is a deterministic draw
+from the *held-out* half of the agreement gold: words where Infopédia and the
+Portal da Língua Portuguesa independently produce the same syllabification, and
+whose syllables concatenate back to the headword. It runs offline, with no
+dataset download.
 
-An opt-in full-lexicon benchmark (the original notebook comparison) runs only
-when ``RUN_LEXICON_BENCHMARK=1`` and the ``datasets`` package + network are
-available.
+The draw comes from the held-out split on purpose. Scoring against words the
+rules were tuned on measures memorization, not syllabification.
+
+The full scoreboard -- every set, no sampling, plus the error taxonomy -- lives
+in ``benchmark/`` and is run with ``python -m benchmark.report``.
 """
 import json
-import os
 import pathlib
 
 import pytest
@@ -20,9 +21,9 @@ from silabificador import syllabify
 
 GOLD_PATH = pathlib.Path(__file__).parent / "gold_sample.json"
 
-# Lower bound on the sample match rate. Measured at 0.998; allow headroom so a
-# benign rule tweak that shifts one or two borderline words does not fail CI,
-# while a real regression still trips it.
+# Lower bound on the held-out sample match rate. Measured at 0.997 on the
+# agreement gold; the headroom absorbs a borderline word or two without letting
+# a real regression through.
 MIN_SAMPLE_ACCURACY = 0.98
 
 
@@ -45,21 +46,12 @@ def test_sample_accuracy_does_not_regress(gold):
 
 
 def test_gold_entries_are_self_consistent(gold):
-    # the gold syllables must concatenate back to the word
     for e in gold:
-        assert "".join(e["syllables"]).lower() == e["word"].replace("-", "").lower()
+        assert "".join(e["syllables"]) == e["word"].lower()
 
 
-@pytest.mark.skipif(os.environ.get("RUN_LEXICON_BENCHMARK") != "1",
-                    reason="set RUN_LEXICON_BENCHMARK=1 to run the full lexicon benchmark")
-def test_full_lexicon_benchmark():
-    from datasets import load_dataset
-    ds = load_dataset("TigreGotico/portuguese_phonetic_lexicon", split="train")
-    region = "lbx"
-    rows = [r for r in ds
-            if r.get("region_code") == region
-            and r.get("word") and r.get("syllables")
-            and "".join(r["syllables"].split("|")).lower() == r["word"].replace("-", "").lower()]
-    correct = sum(1 for r in rows if syllabify(r["word"]) == r["syllables"].split("|"))
-    acc = correct / len(rows)
-    assert acc >= 0.99, f"full-lexicon accuracy {acc:.4f} regressed ({correct}/{len(rows)})"
+def test_output_reconstructs_the_input(gold):
+    # Syllabification may not add, drop, or alter a character. An engine that
+    # scores well while quietly deleting material is not syllabifying.
+    for e in gold:
+        assert "".join(syllabify(e["word"])) == e["word"].lower()

--- a/tests/test_gold.py
+++ b/tests/test_gold.py
@@ -1,0 +1,78 @@
+"""Unit tests for the gold-set builder.
+
+These exercise the provenance and integrity logic on synthetic rows; the real
+lexicon is not downloaded. Rows are ``(word, syllables, infopedia_url)`` --
+an Infopédia row carries a dictionary URL and dot separators, a Portal row has
+neither and uses pipes.
+"""
+from benchmark.gold import TEST_FRACTION, _collect, is_test
+
+URL = "https://www.infopedia.pt/dicionarios/lingua-portuguesa/x"
+
+
+def info(word, syllables):
+    return (word, syllables, URL)
+
+
+def portal(word, syllables):
+    return (word, syllables, "")
+
+
+def test_identical_splits_from_both_sources_are_gold():
+    gold = _collect([info("casa", "ca.sa"), portal("casa", "ca|sa")])
+    assert gold.agreement == {"casa": ("ca", "sa")}
+    assert not gold.disagreement
+
+
+def test_conflicting_splits_are_excluded_not_arbitrated():
+    # ablactar: Infopédia keeps the prefix (ab-), Portal maximizes the onset.
+    # Both are defensible; neither may be scored against.
+    gold = _collect([info("ablactar", "ab.lac.tar"), portal("ablactar", "a|blac|tar")])
+    assert not gold.agreement
+    assert gold.disagreement == {"ablactar": (("ab", "lac", "tar"), ("a", "blac", "tar"))}
+
+
+def test_single_source_words_are_kept_but_segregated():
+    gold = _collect([info("aachenense", "aa.che.nen.se"), portal("xisto", "xis|to")])
+    assert gold.infopedia_only == {"aachenense": ("aa", "che", "nen", "se")}
+    assert gold.portal_only == {"xisto": ("xis", "to")}
+    assert not gold.agreement
+
+
+def test_entries_that_do_not_reconstruct_the_word_are_dropped():
+    # Portal deletes the hyphen; Infopédia drops a syllable outright. A source
+    # that cannot spell the headword is not evidence about the headword.
+    gold = _collect([
+        portal("a-propósito", "a|pro|pó|si|to"),
+        info("acidentadamente", "a.ci.den.ta.men.te"),
+    ])
+    assert not gold.agreement and not gold.infopedia_only and not gold.portal_only
+    assert gold.dropped == {"infopedia": 1, "portal": 1}
+
+
+def test_source_contradicting_itself_is_dropped():
+    gold = _collect([info("casa", "ca.sa"), info("casa", "cas.a")])
+    assert gold.dropped["infopedia"] == 1
+    assert not gold.infopedia_only
+
+
+def test_headwords_are_case_folded():
+    gold = _collect([info("Adonai", "A.do.nai"), portal("adonai", "a|do|nai")])
+    assert gold.agreement == {"adonai": ("a", "do", "nai")}
+
+
+def test_portal_regional_duplicates_collapse():
+    # The orthographic split is region-invariant; the lexicon repeats it once
+    # per phonetic region.
+    rows = [portal("casa", "ca|sa") for _ in range(6)] + [info("casa", "ca.sa")]
+    gold = _collect(rows)
+    assert gold.agreement == {"casa": ("ca", "sa")}
+    assert gold.dropped["portal"] == 0
+
+
+def test_split_assignment_is_content_addressed_and_stable():
+    words = [f"palavra{i}" for i in range(2000)]
+    held = [w for w in words if is_test(w)]
+    assert held == [w for w in words if is_test(w)]  # no order or seed dependence
+    assert 0.15 < len(held) / len(words) < 0.25  # ~TEST_FRACTION
+    assert TEST_FRACTION == 0.2


### PR DESCRIPTION
## What

Rebuilds the benchmark on [`TigreGotico/portuguese-unified-pronunciation-lexicon`](https://huggingface.co/datasets/TigreGotico/portuguese-unified-pronunciation-lexicon) and establishes the baseline the engine is judged against. **No engine change in this PR.**

## The gold

The dataset carries `syllables` from two independent authorities. Neither is taken on faith:

1. **Join-integrity** — an entry is admitted only if its syllables concatenate back to the headword exactly. Drops 1,084 Infopédia and 1,350 Portal entries.
2. **Cross-source agreement** — the two are compared word by word. Only words they *independently agree on* become gold.

| class | words | |
|---|---|---|
| **agreement (gold)** | **35,181** | both sources, identical split |
| infopedia-only | 65,098 | single source, unverified |
| portal-only | 16,680 | single source, unverified |
| disagreement | 135 | excluded — see below |
| dropped | 2,434 | failed join-integrity |

The 135 disagreements are convention conflicts, not noise, so neither answer is scored against:

- **prefix boundary vs onset maximization** — `ablactar`: Infopédia `ab.lac.tar`, Portal `a.blac.tar`
- **etymological hiatus vs diphthong** — `abaulado`: Infopédia `a.bau.la.do`, Portal `a.ba.u.la.do`

The gold is split **dev/test by content hash** (SHA-1 of the word, 80/20). Tuning happens on dev; the number reported is test.

## Baseline — current engine, full sets, no sampling

```
agreement / test (held out)   99.72%    7074/7094
agreement / dev               99.77%   28023/28087
agreement (all)               99.76%   35097/35181
infopedia (all)               90.71%   90959/100279
portal (all)                  99.58%   51641/51861
```

The 99.6% headline describes Portal. On Infopédia — nearly twice as many words — the engine scores **90.71%**.

### Where the 9,320 Infopédia failures go

**8,510 (91%) are corruption: the output does not spell the input.** Hyphens and spaces are deleted:

```
a-histórico       gold=a-his.tó.ri.co       got=a.his.tó.ri.co
ajudante de campo                           got=a.ju.dan.te.de.cam.po
```

`tests/test_accuracy_regression.py` now asserts `"".join(syllabify(w)) == w`, the invariant those 8,574 words break.

The rest is linguistic, and the taxonomy names the causes:

- **hiatus/diphthong resolution** (651) — `abaité` gold `a.ba.i.té`, got `a.bai.té`
- **morpheme boundaries** (~100) — `ad.re.nal`, `sub.li.mi.nar`, `ci.ber.as.sé.di.o`

## Files

- `benchmark/gold.py` — provenance, join-integrity, content-addressed dev/test split
- `benchmark/report.py` — `python -m benchmark.report`: full scoreboard + error taxonomy
- `benchmark/sample.py` — regenerates the committed CI sample
- `tests/gold_sample.json` — redrawn (500 words) from the **held-out** agreement gold
- `tests/test_gold.py` — unit tests for the builder on synthetic rows, no download
- `pyproject.toml` — `[benchmark]` extra; the runtime stays dependency-free
- `.github/workflows/coverage.yml` — `install_extras` takes pip arguments, not an extras name

## Verification

`pytest` — 22 passed. `python -m benchmark.report` produces the numbers above.