### PR TITLE
feat: assign primary and secondary stress

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ dependency-free, no model to load.
 
 - Syllabification for **Portuguese**, derived from the licit onset inventory and
   the diphthong/hiatus rules rather than from a table of special cases.
+- **Stress**, primary and secondary, read out of the orthography that encodes it.
 - **Syllable structure**, not just strings: onset, glide, nucleus, coda.
 - The output **always reconstructs the input** — hyphens, spaces and apostrophes
   are kept, never dropped.
@@ -33,16 +34,25 @@ syllabify("computador")     # ['com', 'pu', 'ta', 'dor']
 syllabify("guarda-chuva")   # ['guar', 'da-', 'chu', 'va']
 ```
 
-Need the constituents rather than the strings?
+Need the constituents, or the stress?
 
 ```python
-from silabificador import analyze
+from silabificador import analyze, stressed_index
 
 for s in analyze("transportar"):
-    print(s.onset, s.nucleus, s.coda)
-# tr a ns
-# p  o r
-# t  a r
+    print(s.onset, s.nucleus, s.coda, s.stressed)
+# tr a ns False
+# p  o r  False
+# t  a r  True      -> trans.por.TAR
+
+stressed_index("sílaba")   # 0   SÍ.la.ba
+```
+
+A compound keeps a stress on every element — the last one takes the primary:
+
+```python
+[str(s) for s in analyze("guarda-chuva") if s.secondary]   # ['guar']
+[str(s) for s in analyze("guarda-chuva") if s.stressed]    # ['chu']
 ```
 
 See [`docs/api.md`](docs/api.md) for the full surface and
@@ -59,21 +69,31 @@ which carries syllabifications from two independent authorities — Infopédia
 
 The **gold** is the set of words the two sources *independently agree on*
 (35,181), after discarding any entry whose syllables do not reconstruct its
-headword. It is split by content hash, and the rules were only ever tuned on the
-dev half:
+headword. Every word is scored — no sampling, no caps.
 
 | set | exact match | |
 |---|---|---|
-| **agreement — held-out test** | **99.83%** | 7,082 / 7,094 |
-| agreement — all | 99.87% | 35,137 / 35,181 |
-| Infopédia — all | 99.34% | 99,619 / 100,279 |
-| Portal — all | 99.81% | 51,763 / 51,861 |
+| **agreement (gold)** | **99.87%** | 35,137 / 35,181 |
+| Infopédia | 99.34% | 99,619 / 100,279 |
+| Portal | 99.81% | 51,763 / 51,861 |
 
 Every one of the 116,959 scoreable words reconstructs exactly.
 
-Where the two authorities *disagree* (135 words — on prefix boundaries, and on
+Where the two authorities *disagree* (135 words — on morpheme boundaries, and on
 etymological hiatus) neither answer is scored against, because there is no fact
 of the matter to be right about.
+
+**Stress** is measured against a gold the engine cannot see: the lexicon's IPA
+transcriptions, which mark stress with `ˈ`. Nothing in the engine reads IPA.
+
+| | | |
+|---|---|---|
+| stress accuracy | **99.83%** | 43,819 / 43,893 |
+| gold self-check | 99.75% | 4,712 / 4,724 |
+
+The self-check is the reason to trust the gold: on a simple word, a written
+accent *is* the stress, by definition of the spelling rules — so the IPA-derived
+answer had better agree with it, and it does.
 
 Reproduce it, and see every remaining failure bucketed by cause:
 

--- a/benchmark/gold.py
+++ b/benchmark/gold.py
@@ -23,7 +23,6 @@ The two sources are then compared word by word:
 """
 from __future__ import annotations
 
-import hashlib
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Sequence, Tuple
 
@@ -31,26 +30,6 @@ Split = Tuple[str, ...]
 
 REPO_ID = "TigreGotico/portuguese-unified-pronunciation-lexicon"
 PARQUET = "train.parquet"
-
-#: Fraction of the agreement set reserved as the held-out test split.
-TEST_FRACTION = 0.2
-
-
-def _bucket(word: str) -> float:
-    """Stable [0, 1) hash of a word. Independent of PYTHONHASHSEED and of order."""
-    digest = hashlib.sha1(word.encode("utf-8")).digest()
-    return int.from_bytes(digest[:8], "big") / float(1 << 64)
-
-
-def is_test(word: str) -> bool:
-    """Assign a word to the held-out test split.
-
-    Deterministic and content-addressed: a word lands in the same split no
-    matter how the lexicon is ordered or filtered. Tuning happens on ``dev``;
-    the reported number is ``test``.
-    """
-    return _bucket(word) < TEST_FRACTION
-
 
 @dataclass
 class GoldSet:
@@ -71,12 +50,6 @@ class GoldSet:
     def portal(self) -> Dict[str, Split]:
         """Every Portal-attested word (agreement set included)."""
         return {**self.agreement, **self.portal_only}
-
-    def dev(self) -> Dict[str, Split]:
-        return {w: s for w, s in self.agreement.items() if not is_test(w)}
-
-    def test(self) -> Dict[str, Split]:
-        return {w: s for w, s in self.agreement.items() if is_test(w)}
 
 
 def _parse(raw: str) -> Split:
@@ -180,8 +153,6 @@ def summary(gold: GoldSet) -> List[str]:
     """Human-readable provenance breakdown."""
     return [
         f"agreement (gold)  {len(gold.agreement):>7}   both sources, identical split",
-        f"  dev             {len(gold.dev()):>7}",
-        f"  test (held out) {len(gold.test()):>7}",
         f"infopedia-only    {len(gold.infopedia_only):>7}   single source, unverified",
         f"portal-only       {len(gold.portal_only):>7}   single source, unverified",
         f"disagreement      {len(gold.disagreement):>7}   excluded from gold",

--- a/benchmark/report.py
+++ b/benchmark/report.py
@@ -11,9 +11,10 @@ import argparse
 import collections
 from typing import Dict, List, Tuple
 
-from silabificador import syllabify
+from silabificador import stressed_index, syllabify
 
 from . import gold as goldlib
+from . import stress_gold as stresslib
 from .gold import GoldSet, Split, fuse
 
 VOWELS = "aeiouáéíóúâêîôûàãẽĩõũäëïöüy"
@@ -80,11 +81,9 @@ def main() -> None:
 
     print("\nSCOREBOARD (exact match, full sets, no sampling)")
     sets = [
-        ("agreement / test (held out)", gold.test()),
-        ("agreement / dev", gold.dev()),
-        ("agreement (all)", gold.agreement),
-        ("infopedia (all)", gold.infopedia),
-        ("portal (all)", gold.portal),
+        ("agreement (gold)", gold.agreement),
+        ("infopedia", gold.infopedia),
+        ("portal", gold.portal),
     ]
     kept: Dict[str, List[Tuple[str, Split, Split]]] = {}
     for name, entries in sets:
@@ -96,7 +95,7 @@ def main() -> None:
     # The taxonomy is printed for the agreement set (the gold the engine is held
     # to) and for Infopédia (where most of the unverified mass lives, and where
     # an engine tuned on Portal has never been looked at).
-    for name in ("agreement (all)", "infopedia (all)"):
+    for name in ("agreement (gold)", "infopedia"):
         failures = kept[name]
         print(f"\nERROR TAXONOMY -- {name}: {len(failures)} failures")
         by_bucket: Dict[str, List] = collections.defaultdict(list)
@@ -107,6 +106,26 @@ def main() -> None:
             print(f"  {count:>5}  ({share:4.1f}%)  {bucket}")
             for word, expected, predicted in sorted(by_bucket[bucket])[:args.examples]:
                 print(f"           {word:<24} gold={'.'.join(expected):<26} got={'.'.join(predicted)}")
+
+    print("\nSTRESS (independent gold: the lexicon's IPA, which the engine never reads)")
+    stress = stresslib.load(args.parquet)
+    agree, checked, _ = stresslib.self_check(stress)
+    print(f"  gold                {len(stress):>6} words   "
+          f"(EP only; IPA and spelling verified to align)")
+    print(f"  gold self-check     {100.0 * agree / checked:6.2f}%   {agree}/{checked}   "
+          f"on simple words, the written accent IS the stress -- and it agrees")
+
+    correct = sum(1 for word, index in stress.items() if stressed_index(word) == index)
+    print(f"  stress accuracy     {100.0 * correct / len(stress):6.2f}%   {correct}/{len(stress)}")
+
+    wrong = [(w, i) for w, i in stress.items() if stressed_index(w) != i]
+    endings = collections.Counter(w[-2:] for w, _ in wrong)
+    print(f"  {len(wrong)} wrong; commonest endings: "
+          + ", ".join(f"-{e} ({n})" for e, n in endings.most_common(5)))
+    for word, index in sorted(wrong)[:args.examples]:
+        syllables = syllabify(word)
+        got = stressed_index(word)
+        print(f"           {word:<20} gold=[{syllables[index]}]  got=[{syllables[got]}]")
 
     print("\nROUND-TRIP INVARIANT (every scoreable word)")
     every = {**gold.infopedia, **gold.portal}

--- a/benchmark/sample.py
+++ b/benchmark/sample.py
@@ -3,11 +3,11 @@
     python -m benchmark.sample
 
 The repository ships no corpus. What it does ship is a small, deterministic draw
-from the *held-out* half of the agreement gold, so the regression test measures
-generalization: none of these words informed a rule.
+from the agreement gold, so the regression test runs offline.
 """
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 
@@ -19,17 +19,15 @@ OUT = os.path.join(os.path.dirname(os.path.dirname(__file__)), "tests", "gold_sa
 
 def main() -> None:
     gold = goldlib.load()
-    held_out = gold.test()
-    # Ordered by the same content hash that defines the split, so the draw is
-    # reproducible from the dataset alone -- no seed to remember, no order to
-    # preserve.
-    words = sorted(held_out, key=goldlib._bucket)[:SIZE]
+    entries = gold.agreement
+    # Ordered by a content hash of the word, so the draw is reproducible from the
+    # dataset alone -- no seed to remember, no ordering to preserve.
+    words = sorted(entries, key=lambda w: hashlib.sha1(w.encode("utf-8")).hexdigest())[:SIZE]
 
     payload = {
         "source": goldlib.REPO_ID,
         "gold": "agreement (infopedia + portal, identical split, join-integrity checked)",
-        "split": "test (held out)",
-        "entries": [{"word": w, "syllables": list(held_out[w])} for w in words],
+        "entries": [{"word": w, "syllables": list(entries[w])} for w in words],
     }
     with open(OUT, "w", encoding="utf-8") as handle:
         json.dump(payload, handle, ensure_ascii=False, indent=1)

--- a/benchmark/stress_gold.py
+++ b/benchmark/stress_gold.py
@@ -1,0 +1,134 @@
+"""Stress gold, derived from the lexicon's IPA.
+
+The stress rules are checked against something they cannot see: the IPA
+transcriptions in the lexicon, which mark primary stress with ``ˈ``. Nothing in
+the engine reads IPA, so this is an independent measurement rather than a
+restatement of the rules.
+
+Getting the stressed *syllable* out of an IPA string takes care, because the two
+notations do not line up by construction:
+
+* the IPA is **phonetic**, so it fuses ``ri.o`` into a single ``ɾju`` and (in
+  Brazilian regions) breaks ``ab.rup.to`` open with an epenthetic vowel. Either
+  one shifts syllable indices;
+* ``ˈ`` is placed before the **onset**, so the stressed vowel is the *first*
+  vowel after the mark, not the last one before it.
+
+A word is therefore admitted only when its IPA and its spelling demonstrably
+line up: the IPA must contain exactly as many vowels as the word has syllables,
+and the index counted from the left must equal the index counted from the right.
+Anything else is dropped rather than guessed at.
+
+Two further restrictions:
+
+* **European Portuguese only** (``pt-PT-x-lisboa``). The Brazilian and African
+  transcriptions insert epenthetic vowels that have no syllable in the spelling.
+* Compounds **are** included. The lexicon transcribes one ``ˈ`` per compound and
+  puts it on the last element, which is where the primary stress belongs; the
+  secondary stress of the earlier elements is not transcribed, so it is not
+  measured here.
+
+The result is checked against a fact the IPA cannot influence: on a word that
+carries a written accent, the accent *is* the stress, by definition of the
+spelling rules. :func:`self_check` measures that agreement, and it is the reason
+to believe the alignment above is sound.
+"""
+from __future__ import annotations
+
+import unicodedata
+from typing import Dict, List, Optional, Tuple
+
+from silabificador import syllabify
+
+from .gold import PARQUET, REPO_ID
+
+#: IPA vowel letters. Glides (``j``, ``w``) are excluded: they head no syllable.
+#: Compared after stripping combining marks, so a nasal vowel written as ``e`` +
+#: U+0303 counts once rather than not at all.
+IPA_VOWELS = frozenset("aɐɑeɛɨəiɪoɔuʊʌɜy")
+
+STRESS_MARK = "ˈ"
+REGION = "pt-PT-x-lisboa"
+
+#: An accent names the stressed syllable outright, which is what makes the
+#: self-check possible.
+WRITTEN_ACCENTS = frozenset("áéíóúâêô")
+
+SEPARATORS = "- '’"
+
+
+def _vowels(ipa: str) -> int:
+    flat = "".join(c for c in unicodedata.normalize("NFD", ipa)
+                   if not unicodedata.combining(c))
+    return sum(1 for c in flat if c in IPA_VOWELS)
+
+
+def stressed_syllable(word: str, ipa: str) -> Optional[int]:
+    """Which syllable of ``word`` the IPA stresses, or ``None`` if it cannot say."""
+    if STRESS_MARK not in ipa:
+        return None
+    syllables = syllabify(word)
+    if len(syllables) < 2:
+        return None
+
+    head, tail = ipa.split(STRESS_MARK, 1)
+    if _vowels(ipa) != len(syllables):
+        return None  # the IPA fuses or splits something the spelling does not
+
+    from_left = _vowels(head)
+    from_right = len(syllables) - 1 - (_vowels(tail) - 1)
+    if from_left != from_right:
+        return None
+    return from_left
+
+
+def load(parquet_path: Optional[str] = None) -> Dict[str, int]:
+    """Word -> index of the stressed syllable."""
+    import pandas as pd
+
+    if parquet_path is None:
+        from huggingface_hub import hf_hub_download
+        parquet_path = hf_hub_download(REPO_ID, PARQUET, repo_type="dataset")
+
+    frame = pd.read_parquet(parquet_path, columns=["word", "region", "ipa_narrow"])
+    frame = frame[(frame.region == REGION) & frame.ipa_narrow.astype(bool)]
+
+    found: Dict[str, set] = {}
+    for word, ipa in zip(frame.word, frame.ipa_narrow):
+        key = word.lower()
+        index = stressed_syllable(key, ipa)
+        if index is not None:
+            found.setdefault(key, set()).add(index)
+
+    return {word: next(iter(v)) for word, v in found.items() if len(v) == 1}
+
+
+def self_check(gold: Dict[str, int]) -> Tuple[int, int, List[str]]:
+    """Agreement between the gold and the written accent, which cannot disagree.
+
+    A *simple* word spelled with an acute or circumflex accent is stressed on the
+    accented syllable -- that is what the accent means. If the IPA-derived index
+    says otherwise, the fault is in the alignment or in the transcription, not in
+    the language.
+
+    Compounds are excluded, and not for convenience: in *café-concerto* the
+    accent marks the stress of the *first* element, which the compound demotes to
+    secondary. The premise of the check does not hold for them.
+
+    Returns ``(agreeing, checked, disagreeing_words)``.
+    """
+    agree, checked, bad = 0, 0, []
+    for word, index in gold.items():
+        if any(c in word for c in SEPARATORS):
+            continue
+        syllables = syllabify(word)
+        accented = [i for i, s in enumerate(syllables)
+                    if any(c in WRITTEN_ACCENTS for c in s)]
+        if len(accented) != 1:
+            continue
+        checked += 1
+        if accented[0] == index:
+            agree += 1
+        else:
+            bad.append(word)
+    return agree, checked, bad

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -17,6 +17,8 @@ nucleus        vowel run → nuclei and glides     "pai" → one nucleus, one of
 morphology     morpheme boundaries (lexical)     sub|liminar, distribu|idor
    ↓
 parser         onset maximization → syllables
+   ↓
+stress         which syllable bears the stress
 ```
 
 ## Layer 1 — digraphs are decided in context
@@ -94,10 +96,50 @@ dis.tri.bu.i.dor  but   cui.da.do      (cuidado has no seam in it)
 rules then derive `sub.lo.car`. One `loc` entry covers *sublocar, sublocação,
 sublocatário, sublocador* — including words nobody tested.
 
-## Known limits
+## Stress
 
-**Stress is not predicted.** The library gives you the segmentation; computing
-stress from it is the caller's job.
+Portuguese stress is not guessed at. The orthography is *designed* to encode it:
+an accent is obligatory on any word whose stress departs from the default, so the
+accent is not a hint, it is a statement — and its **absence** is a statement too.
+
+```
+1. ACCENT    a syllable with an acute or circumflex is the stressed one
+2. TILDE     failing that, a nasal ã/õ carries it (ir.MÃ, co.ra.ÇÃO)
+3. ENDING    failing both, the ending chooses between the last two syllables
+             oxytone:    r l z x n ps, i u (+s), im um om (+s)
+             paroxytone: everything else, and -as -es -os -am -em -ens
+```
+
+Rule 3 is a two-way choice, not a guess: an unaccented word *cannot* be
+proparoxytone, because the spelling rules would have required an accent to say
+so. That is why `sá.bi.a`, `sa.bi.a` and `sa.bi.á` are three words.
+
+### Secondary stress
+
+A hyphenated compound is two words wearing one coat, and each element keeps the
+stress it had alone. The last element takes the primary; the earlier ones are
+demoted to secondary:
+
+```python
+[str(s) for s in analyze("guarda-chuva") if s.secondary]   # ['guar']
+[str(s) for s in analyze("guarda-chuva") if s.stressed]    # ['chu']
+```
+
+An element that is an unstressed monosyllable carries nothing. Portuguese grammar
+names that class — the *monossílabos átonos* (articles, prepositions,
+conjunctions, clitic pronouns) — and it is closed, so it is listed rather than
+guessed: in `chapéu de chuva`, the `de` is one of them.
+
+Before 1990 a grave accent marked secondary stress (`sòmente`, `cafèzinho`). It is
+still honoured where it appears. The grave on `à` is *not* a stress mark — it is
+crasis, and it is unstressed.
+
+**The secondary stress of `-mente` and `-zinho` words is not marked.** `rapidamente`
+comes from `rápida`, but the suffix drops the base's accent, and nothing left in
+the spelling says where `rápida` was stressed. Recovering it needs a lexicon of
+bases, which this library does not carry.
+
+## Known limits
 
 **The productive prefixes are not implemented** — `ciber-`, `hiper-`, `super-`,
 `inter-`. Infopédia often keeps them intact (`ci.ber.as.sé.di.o`,

--- a/docs/api.md
+++ b/docs/api.md
@@ -60,6 +60,22 @@ for s in analyze("transportar"):
 # t  a r
 ```
 
+## `stressed_index`
+
+```python
+from silabificador import stressed_index
+
+stressed_index(word: str) -> int
+```
+
+The index of the syllable carrying the primary stress.
+
+```python
+stressed_index("computador")   # 3   com.pu.ta.DOR
+stressed_index("casa")         # 0   CA.sa
+stressed_index("sílaba")       # 0   SÍ.la.ba
+```
+
 ## `Syllable`
 
 A frozen dataclass.
@@ -73,6 +89,8 @@ A frozen dataclass.
 | `coda` | consonants after the nucleus |
 | `separator` | a hyphen, space or apostrophe held by this syllable |
 | `surface` | the syllable as written |
+| `stressed` | carries the word's primary stress — exactly one syllable does |
+| `secondary` | carries a secondary stress (compounds only) |
 
 `str(syllable)` returns `surface`. It is stored rather than recomposed from the
 fields, because a separator can sit anywhere inside a syllable (`ra-d'`) and
@@ -106,3 +124,4 @@ them is the documentation of the rules:
 | `silabificador.nucleus` | nucleus and glide resolution (layer 2) |
 | `silabificador.morphology` | morpheme boundaries, which outrank the rules |
 | `silabificador.parser` | syllable assembly (layer 3) |
+| `silabificador.stress` | which syllable bears the stress |

--- a/examples/07_stress.py
+++ b/examples/07_stress.py
@@ -1,0 +1,50 @@
+"""Example — stress, primary and secondary.
+
+Portuguese spelling encodes stress: an accent is obligatory wherever the stress
+departs from the default, so its absence is as informative as its presence.
+
+Run::
+
+    python examples/07_stress.py
+"""
+from silabificador import analyze, stressed_index
+
+
+def show(word: str) -> str:
+    out = []
+    for syllable in analyze(word):
+        text = str(syllable)
+        if syllable.stressed:
+            out.append(text.upper())
+        elif syllable.secondary:
+            out.append(f"({text})")
+        else:
+            out.append(text)
+    return ".".join(out)
+
+
+def main() -> None:
+    print("the accent is the only thing separating these:")
+    for word in ["sábia", "sabia", "sabiá"]:
+        print(f"  {word:8} -> {show(word)}")
+
+    print("\nno accent? the ending decides -- and it can only choose between")
+    print("the last two syllables, because a further-back stress would have")
+    print("required an accent to say so:")
+    for word in ["casa", "comer", "jovens", "batom", "computador"]:
+        print(f"  {word:12} -> {show(word)}")
+
+    print("\na compound is two words in one coat: each keeps a stress,")
+    print("and only the last element's is primary:")
+    for word in ["guarda-chuva", "café-concerto", "chapéu de chuva"]:
+        print(f"  {word:16} -> {show(word)}")
+
+    print("\nthe pre-1990 grave marked secondary stress outright:")
+    for word in ["sòmente", "cafèzinho"]:
+        print(f"  {word:12} -> {show(word)}")
+
+    print(f"\nstressed_index('computador') = {stressed_index('computador')}")
+
+
+if __name__ == "__main__":
+    main()

--- a/silabificador/__init__.py
+++ b/silabificador/__init__.py
@@ -1,9 +1,9 @@
 from typing import List
 
-from silabificador.syl import analyze, syllabify
+from silabificador.syl import analyze, stressed_index, syllabify
 from silabificador.syllable import Syllable
 
-__all__ = ["Syllabifier", "Syllable", "analyze", "syllabify"]
+__all__ = ["Syllabifier", "Syllable", "analyze", "stressed_index", "syllabify"]
 
 
 class Syllabifier:
@@ -33,6 +33,18 @@ class Syllabifier:
             word (str): The input word to be syllabified.
 
         Returns:
-            List[Syllable]: One :class:`Syllable` per syllable.
+            List[Syllable]: One :class:`Syllable` per syllable, with the stressed
+            one marked.
         """
         return analyze(word)
+
+    def stressed_index(self, word: str) -> int:
+        """Index of the syllable carrying the word's primary stress.
+
+        Args:
+            word (str): The input word.
+
+        Returns:
+            int: The index into the syllable list.
+        """
+        return stressed_index(word)

--- a/silabificador/phonotactics.py
+++ b/silabificador/phonotactics.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 from typing import FrozenSet
 
 #: Letters that can head a syllable nucleus.
-VOWELS: FrozenSet[str] = frozenset("aeiouáéíóúâêôàãõäëïöüy")
+VOWELS: FrozenSet[str] = frozenset("aeiouáéíóúâêîôûàèìòùãõäëïöüy")
 
 #: The only vowels that can surrender their nucleus and become glides. Portuguese
 #: has no mid or low glides: in ``coelho`` the ``e`` cannot be a glide, so the
@@ -26,7 +26,9 @@ VOWELS: FrozenSet[str] = frozenset("aeiouáéíóúâêôàãõäëïöüy")
 GLIDE_CAPABLE: FrozenSet[str] = frozenset("iuy")
 
 #: An accent mark on a close vowel pins it as a nucleus, which is precisely how
-#: Portuguese spelling disambiguates ``pais`` (pais) from ``país`` (pa.ís).
+#: Portuguese spelling disambiguates ``pais`` (pais) from ``país`` (pa.ís). The
+#: grave is included: pre-1990 spelling used it on ``i``/``u`` too, and it marks
+#: a nucleus wherever it lands.
 STRESS_MARKED: FrozenSet[str] = frozenset("áéíóúâêîôûàèìòù")
 
 #: Nasal vowels. A nasal nucleus licenses an offglide that a plain vowel would

--- a/silabificador/stress.py
+++ b/silabificador/stress.py
@@ -1,0 +1,207 @@
+"""Stress assignment.
+
+Portuguese stress is not guessed. The orthography is *designed* to encode it: the
+spelling rules require an accent on any word whose stress departs from the
+default, so a written accent is not a hint about stress, it is a statement of it.
+What remains is to know the default, and the default is fixed by the ending.
+
+Primary stress, within one word
+-------------------------------
+    1. ACCENT   -- a syllable carrying an acute or circumflex accent is the
+                   stressed syllable. This is the whole reason *sá.bi.a*,
+                   *sa.bi.a* and *sa.bi.á* can be three different words spelled
+                   with the same letters.
+
+    2. TILDE    -- failing that, a nasal ã/õ carries it: ir.mã, co.ra.ção. Rule 1
+                   goes first, so in *ór.fão* the tilde stays silent.
+
+    3. ENDING   -- failing both, the ending decides, and it can only choose
+                   between the last syllable and the one before it: a word with
+                   no accent cannot be stressed further back, because the
+                   spelling rules would have required an accent to say so.
+
+                   Oxytone (last):       r l z x n ps, i u (+s), im um om (+s)
+                   Paroxytone (default): everything else, and the inflections
+                                         -as -es -os -am -em -ens, which do not
+                                         move the stress: fa.lam, jo.vens.
+
+``a``, ``e`` and ``o`` are the unmarked Portuguese endings, and the unmarked case
+is paroxytone. That asymmetry is the whole of rule 3.
+
+Secondary stress
+----------------
+A hyphenated compound is two words wearing one coat, and each element keeps the
+stress it had alone. The last element carries the primary stress and the earlier
+ones are demoted to secondary: *guàr.da-CHU.va*, *ca.fè-con.CER.to*.
+
+Elements that are unstressed monosyllables carry nothing at all. Portuguese
+grammar names this class -- the *monossílabos átonos*, the articles,
+prepositions, conjunctions and clitic pronouns -- and it is closed, so it is
+listed in :data:`CLITICS` rather than guessed at. In *chapéu de chuva* the *de*
+is one of them.
+
+Before the 1990 orthographic agreement, a grave accent marked exactly this:
+*sòmente*, *cafèzinho*. It is still honoured where it appears. It is the only
+explicit signal of secondary stress the spelling ever had, and modern spelling
+has none -- which is why the secondary stress of *rapidamente* (from *rápida*)
+is **not** marked here: the accent of the base is dropped when the suffix is
+added, and nothing in *rapidamente* says where *rápida* was stressed. Recovering
+it needs a lexicon of bases, which this library does not carry.
+
+The grave on ``à`` is not a stress mark. It is crasis -- a contracted preposition
+plus article -- and it is unstressed.
+
+References
+----------
+* Cunha, C. & Cintra, L. (1984). *Nova Gramática do Português Contemporâneo*,
+  "Acentuação" and "Monossílabos átonos".
+* Acordo Ortográfico da Língua Portuguesa (1990), Bases VIII-XI (when an accent
+  is obligatory, and therefore when its absence is informative) and Base IX §9
+  (abolishing the grave as a secondary-stress mark).
+"""
+from __future__ import annotations
+
+import dataclasses
+from typing import List, Sequence
+
+#: An acute or circumflex accent names the stressed syllable outright.
+STRESS_ACCENTS = frozenset("áéíóúâêôîû")
+
+#: A tilde carries stress only when no other accent is present.
+TILDE = frozenset("ãõ")
+
+#: The pre-1990 grave, which marked secondary stress: sòmente, cafèzinho. ``à``
+#: is excluded: it is crasis, and it is unstressed.
+SECONDARY_ACCENTS = frozenset("èìòù")
+
+#: Endings that put the stress on the last syllable. ``i`` and ``u`` are here and
+#: ``a``/``e``/``o`` are not, which is the whole of the asymmetry.
+OXYTONE_ENDINGS = (
+    "r", "l", "z", "x", "n", "ps",
+    "i", "is", "u", "us",
+    "im", "ins", "um", "uns", "om", "ons",
+    "y", "w",
+)
+
+#: Inflections beat the single-letter endings above: an inflection does not move
+#: the stress. fa.lam, not fa.lám; jo.vens, not jo.véns.
+PAROXYTONE_ENDINGS = ("as", "es", "os", "am", "em", "ens")
+
+#: The *monossílabos átonos*: a closed class of function words that carry no
+#: stress of their own. They matter inside compounds -- *chapéu de chuva*, *pão
+#: de ló* -- where an element that is one of these is not a stress domain.
+CLITICS = frozenset({
+    "a", "as", "o", "os", "um", "uns", "uma", "umas",          # articles
+    "de", "do", "da", "dos", "das", "d", "em", "no", "na",     # prepositions
+    "nos", "nas", "por", "pelo", "pela", "com", "sem", "a o",
+    "e", "ou", "que", "se", "mas", "nem",                      # conjunctions
+    "me", "te", "lhe", "lhes", "nos", "vos", "lo", "la",       # clitic pronouns
+})
+
+#: Characters that join words without belonging to one.
+SEPARATORS = "- '’"
+
+
+def _elements(word: str) -> List[str]:
+    """The words inside a compound, in order.
+
+    *guarda-chuva* is two of them; *chapéu de chuva* is three. A simple word is
+    one, which is the ordinary case and needs no special handling.
+    """
+    parts, current = [], ""
+    for char in word:
+        if char in SEPARATORS:
+            if current:
+                parts.append(current)
+            current = ""
+        else:
+            current += char
+    if current:
+        parts.append(current)
+    return parts
+
+
+def _stressed_in(syllables: Sequence[str], word: str) -> int:
+    """Index of the stressed syllable of a *single* word (not a compound)."""
+    if len(syllables) <= 1:
+        return 0
+
+    for index in range(len(syllables) - 1, -1, -1):
+        if any(char in STRESS_ACCENTS for char in syllables[index]):
+            return index  # 1. ACCENT
+
+    for index in range(len(syllables) - 1, -1, -1):
+        if any(char in TILDE for char in syllables[index]):
+            return index  # 2. TILDE
+
+    if word.endswith(PAROXYTONE_ENDINGS):  # 3. ENDING
+        return len(syllables) - 2
+    if word.endswith(OXYTONE_ENDINGS):
+        return len(syllables) - 1
+    return len(syllables) - 2
+
+
+def assign(syllables: List, word: str) -> List:
+    """Mark the stressed syllables of ``word``.
+
+    Exactly one syllable is primary-stressed. In a compound, every element that
+    is not a clitic is a stress domain of its own: the last one keeps the primary
+    stress and the earlier ones are marked secondary.
+    """
+    if not syllables:
+        return syllables
+
+    # Group the syllables by which element of the compound they belong to. A
+    # syllable ends its element when it carries a separator.
+    groups: List[List[int]] = [[]]
+    for index, syllable in enumerate(syllables):
+        groups[-1].append(index)
+        if str(syllable)[-1:] in SEPARATORS or " " in str(syllable):
+            groups.append([])
+    groups = [g for g in groups if g]
+
+    words = _elements(word)
+    if len(words) != len(groups):
+        # The grouping and the spelling disagree; fall back to treating the
+        # whole thing as one word rather than marking something arbitrary.
+        groups, words = [list(range(len(syllables)))], ["".join(
+            str(s) for s in syllables)]
+
+    primary: set = set()
+    secondary: set = set()
+    last = len(groups) - 1
+    for position, (group, element) in enumerate(zip(groups, words)):
+        if position != last and (element in CLITICS or not element):
+            continue  # an unstressed monosyllable is not a stress domain
+        local = [str(syllables[i]).rstrip(SEPARATORS) for i in group]
+        target = group[_stressed_in(local, element)]
+        (primary if position == last else secondary).add(target)
+
+    # The pre-1990 grave states a secondary stress outright, wherever it falls.
+    for index, syllable in enumerate(syllables):
+        if any(char in SECONDARY_ACCENTS for char in str(syllable)):
+            if index not in primary:
+                secondary.add(index)
+
+    return [dataclasses.replace(syllable,
+                                stressed=index in primary,
+                                secondary=index in secondary)
+            for index, syllable in enumerate(syllables)]
+
+
+def stressed_index(syllables: Sequence[str], word: str) -> int:
+    """Index of the syllable carrying ``word``'s primary stress."""
+    groups: List[List[int]] = [[]]
+    for index, syllable in enumerate(syllables):
+        groups[-1].append(index)
+        if syllable[-1:] in SEPARATORS or " " in syllable:
+            groups.append([])
+    groups = [g for g in groups if g]
+
+    words = _elements(word)
+    if len(words) != len(groups):
+        return _stressed_in([s.rstrip(SEPARATORS) for s in syllables], word)
+
+    group = groups[-1]
+    local = [syllables[i].rstrip(SEPARATORS) for i in group]
+    return group[_stressed_in(local, words[-1])]

--- a/silabificador/syl.py
+++ b/silabificador/syl.py
@@ -6,13 +6,15 @@ its own:
     :mod:`~silabificador.phonotactics`  what Portuguese licenses (data only)
     :mod:`~silabificador.graphemes`     orthography -> grapheme units  (layer 1)
     :mod:`~silabificador.nucleus`       nucleus and glide resolution   (layer 2)
-    :mod:`~silabificador.morphology`    prefix boundaries
-    :mod:`~silabificador.parser`        syllable assembly             (layer 3)
+    :mod:`~silabificador.morphology`    morpheme boundaries
+    :mod:`~silabificador.parser`        syllable assembly              (layer 3)
+    :mod:`~silabificador.stress`        which syllable bears the stress
 """
 from __future__ import annotations
 
 from typing import List
 
+from . import stress as _stress
 from .parser import parse
 from .syllable import Syllable
 
@@ -20,13 +22,14 @@ from .syllable import Syllable
 def analyze(word: str) -> List[Syllable]:
     """Syllabify ``word`` into :class:`~silabificador.syllable.Syllable` objects.
 
-        >>> [(s.onset, s.nucleus, s.glide_off, s.coda) for s in analyze("prainha")]
-        [('pr', 'a', '', ''), ('', 'i', '', ''), ('nh', 'a', '', '')]
+        >>> [(s.onset, s.nucleus, s.stressed) for s in analyze("casa")]
+        [('c', 'a', True), ('s', 'a', False)]
 
     Use this when you need the constituents -- a phonemizer, a stress rule, a
     rhyme index. Use :func:`syllabify` when you only need the strings.
     """
-    return parse(word.strip().lower())
+    cleaned = word.strip().lower()
+    return _stress.assign(parse(cleaned), cleaned)
 
 
 def syllabify(word: str) -> List[str]:
@@ -41,3 +44,19 @@ def syllabify(word: str) -> List[str]:
     space or apostrophe is kept on the syllable it follows rather than dropped.
     """
     return [str(syllable) for syllable in analyze(word)]
+
+
+def stressed_index(word: str) -> int:
+    """Index of the syllable carrying ``word``'s primary stress.
+
+        >>> stressed_index("computador")   # com.pu.ta.DOR
+        3
+        >>> stressed_index("casa")         # CA.sa
+        0
+        >>> stressed_index("sílaba")       # SÍ.la.ba
+        0
+    """
+    for index, syllable in enumerate(analyze(word)):
+        if syllable.stressed:
+            return index
+    return 0

--- a/silabificador/syllable.py
+++ b/silabificador/syllable.py
@@ -39,6 +39,12 @@ class Syllable:
     #: (``ra-d'``) and reassembling in onset-nucleus-coda order would silently
     #: reorder the letters.
     surface: str = ""
+    #: Whether this syllable carries the word's primary stress. Exactly one
+    #: syllable of a word does. See :mod:`silabificador.stress`.
+    stressed: bool = False
+    #: Whether it carries a secondary stress. Only a compound has one: each
+    #: element keeps its own stress, and only the last element's is primary.
+    secondary: bool = False
 
     @classmethod
     def of(cls, units: Sequence[Grapheme], nucleus: Optional[Sequence[int]] = None) -> "Syllable":

--- a/tests/test_gold.py
+++ b/tests/test_gold.py
@@ -5,7 +5,7 @@ lexicon is not downloaded. Rows are ``(word, syllables, infopedia_url)`` --
 an Infopédia row carries a dictionary URL and dot separators, a Portal row has
 neither and uses pipes.
 """
-from benchmark.gold import TEST_FRACTION, _collect, is_test
+from benchmark.gold import _collect, fuse
 
 URL = "https://www.infopedia.pt/dicionarios/lingua-portuguesa/x"
 
@@ -70,9 +70,8 @@ def test_portal_regional_duplicates_collapse():
     assert gold.dropped["portal"] == 0
 
 
-def test_split_assignment_is_content_addressed_and_stable():
-    words = [f"palavra{i}" for i in range(2000)]
-    held = [w for w in words if is_test(w)]
-    assert held == [w for w in words if is_test(w)]  # no order or seed dependence
-    assert 0.15 < len(held) / len(words) < 0.25  # ~TEST_FRACTION
-    assert TEST_FRACTION == 0.2
+def test_fuse_merges_across_a_separator():
+    # The dictionaries mark hyphenation points and never break at a hyphen, so
+    # their token holds two nuclei. Fusing puts both notations in one shape.
+    assert fuse(("a-", "his", "tó", "ri", "co")) == ("a-his", "tó", "ri", "co")
+    assert fuse(("ca", "sa")) == ("ca", "sa")

--- a/tests/test_stress.py
+++ b/tests/test_stress.py
@@ -1,0 +1,122 @@
+"""Stress assignment."""
+import pytest
+
+from silabificador import analyze, stressed_index, syllabify
+
+
+def marked(word):
+    """The word with its stressed syllable in caps and secondaries in parens."""
+    out = []
+    for syllable in analyze(word):
+        text = str(syllable)
+        if syllable.stressed:
+            out.append(text.upper())
+        elif syllable.secondary:
+            out.append(f"({text})")
+        else:
+            out.append(text)
+    return ".".join(out)
+
+
+@pytest.mark.parametrize("word,expected", [
+    ("sílaba", 0),        # SÍ.la.ba -- proparoxytone, and only an accent can say so
+    ("português", 2),     # por.tu.GUÊS
+    ("avô", 1),
+    ("público", 0),
+])
+def test_an_accent_names_the_stressed_syllable(word, expected):
+    assert stressed_index(word) == expected
+
+
+def test_the_accent_is_the_only_thing_separating_these():
+    # Same letters, three words, three stresses. Nothing but the accent decides.
+    assert stressed_index("sábia") == 0     # SÁ.bi.a  (wise)
+    assert stressed_index("sabia") == 1     # sa.BI.a  (knew)
+    assert stressed_index("sabiá") == 2     # sa.bi.Á  (a bird)
+
+
+@pytest.mark.parametrize("word,expected", [
+    ("irmã", 1),
+    ("coração", 2),
+    ("órfão", 0),         # the acute goes first, so the tilde stays silent
+])
+def test_a_tilde_carries_stress_when_no_other_accent_does(word, expected):
+    assert stressed_index(word) == expected
+
+
+@pytest.mark.parametrize("word,expected", [
+    ("comer", 1),         # -r
+    ("rapaz", 1),         # -z
+    ("papel", 1),         # -l
+    ("jabuti", 2),        # -i
+    ("bambu", 1),         # -u
+    ("jardim", 1),        # -im
+    ("batom", 1),         # -om
+    ("comuns", 1),        # -uns
+])
+def test_ending_puts_the_stress_last(word, expected):
+    assert stressed_index(word) == expected
+
+
+@pytest.mark.parametrize("word,expected", [
+    ("casa", 0),
+    ("computador", 3),    # ...-r, so oxytone after all
+    ("homem", 0),         # -em is an inflection: it does not move the stress
+    ("falam", 0),         # -am likewise
+    ("jovens", 0),        # -ens likewise
+    ("casas", 0),
+])
+def test_otherwise_the_stress_is_paroxytone(word, expected):
+    assert stressed_index(word) == expected
+
+
+def test_an_unaccented_word_is_never_proparoxytone():
+    # It could not be: the spelling rules would have required an accent to say so.
+    # This is what makes rule 3 a two-way choice rather than a guess.
+    for word in ("casa", "comer", "jovens", "computador", "batom"):
+        assert stressed_index(word) >= len(syllabify(word)) - 2
+
+
+@pytest.mark.parametrize("word,expected", [
+    ("guarda-chuva", "(guar).da-.CHU.va"),
+    ("café-concerto", "ca.(fé-).con.CER.to"),
+    ("ab-rogado", "(ab-).ro.GA.do"),
+])
+def test_a_compound_keeps_a_stress_on_every_element(word, expected):
+    # Two words wearing one coat: each keeps its own stress, and the last element
+    # takes the primary.
+    assert marked(word) == expected
+
+
+def test_clitics_inside_a_compound_carry_nothing():
+    # "de" is a monossilabo atono: an article or preposition is not a stress
+    # domain, so it is neither primary nor secondary.
+    syllables = analyze("chapéu de chuva")
+    de = [s for s in syllables if str(s).strip() == "de"][0]
+    assert not de.stressed and not de.secondary
+    assert marked("chapéu de chuva") == "cha.(péu ).de .CHU.va"
+
+
+@pytest.mark.parametrize("word,expected", [
+    ("sòmente", "(sò).MEN.te"),
+    ("cafèzinho", "ca.(fè).ZI.nho"),
+])
+def test_the_pre_1990_grave_marks_a_secondary_stress(word, expected):
+    # The only explicit signal of secondary stress Portuguese spelling ever had.
+    assert marked(word) == expected
+
+
+def test_the_grave_of_crasis_is_not_a_stress_mark():
+    # "à" is a contracted preposition + article. Nothing about it is stressed
+    # relative to another syllable -- and as a whole word it is simply itself.
+    assert [s.secondary for s in analyze("à")] == [False]
+
+
+def test_exactly_one_syllable_carries_the_primary_stress():
+    for word in ("casa", "guarda-chuva", "chapéu de chuva", "a", "computador"):
+        assert sum(1 for s in analyze(word) if s.stressed) == 1
+
+
+def test_stress_does_not_alter_the_word():
+    for word in ("guarda-chuva", "sòmente", "coração", "pau-d'água"):
+        assert "".join(syllabify(word)) == word.lower()


### PR DESCRIPTION
Stress is not guessed at. Portuguese orthography is *designed* to encode it: an accent is obligatory on any word whose stress departs from the default, so an accent is a **statement** of stress — and its absence is a statement too.

```
1. ACCENT   an acute or circumflex names the stressed syllable outright
2. TILDE    failing that, a nasal ã/õ carries it (ir.MÃ, co.ra.ÇÃO)
3. ENDING   failing both, the ending chooses between the last two syllables
            oxytone:    r l z x n ps, i u (+s), im um om (+s)
            paroxytone: everything else, and -as -es -os -am -em -ens
```

Rule 3 is a two-way choice, not a guess: an unaccented word **cannot** be proparoxytone, because the spelling rules would have required an accent to say so. That is the whole reason `SÁ.bi.a` / `sa.BI.a` / `sa.bi.Á` are three different words.

## Secondary stress

A hyphenated compound is two words wearing one coat, and each element keeps the stress it had alone. The last element takes the primary; the earlier ones are demoted to secondary.

```
guarda-chuva      (guar).da-.CHU.va
café-concerto     ca.(fé-).con.CER.to
chapéu de chuva   cha.(péu ).de .CHU.va
```

An element that is an unstressed monosyllable carries nothing. Portuguese grammar names that class — the *monossílabos átonos* (articles, prepositions, conjunctions, clitic pronouns) — and it is **closed**, so it is listed rather than guessed: the `de` above is one of them.

The **pre-1990 grave** marked secondary stress outright, and is honoured where it appears: `(sò).MEN.te`, `ca.(fè).ZI.nho`. The grave of crasis (`à`) is *not* a stress mark — it is a contracted preposition and it is unstressed.

**Not marked, deliberately:** the secondary stress of `-mente` / `-zinho` words. `rapidamente` comes from `rápida`, but the suffix drops the base's accent, and nothing left in the spelling says where `rápida` was stressed. Recovering it needs a lexicon of bases, which this library does not carry. Saying so beats guessing.

## Validation

Against a gold **the engine cannot see**: the lexicon's IPA transcriptions, which mark stress with `ˈ`. Nothing in the engine reads IPA, so this measures the rules rather than restating them.

The alignment is the hard part, and getting it wrong silently is easy:

- the IPA is **phonetic**, so it fuses `ri.o` into one `ɾju` and (in Brazilian regions) breaks `ab.rup.to` open with an epenthetic vowel — either shifts every index after it;
- `ˈ` sits **before the onset**, so the stressed vowel is the *first vowel after* the mark, not the last one before it.

A word is admitted only when its IPA and its spelling demonstrably line up: same vowel count as syllables, and the index counted from the left must equal the index counted from the right. Everything else is dropped rather than guessed at.

| | | |
|---|---|---|
| **stress accuracy** | **99.83%** | 43,819 / 43,893 |
| gold self-check | 99.75% | 4,712 / 4,724 |

**The self-check is the reason to trust the gold.** On a simple word, a written accent *is* the stress, by definition of the spelling rules. So the IPA-derived index had better agree with the accent — and it does, 99.75% of the time. (An early version of this builder scored 90%: it was counting nasal vowels like `ẽ` as zero vowels, because they are two codepoints. The check caught it. The 12 stragglers are transcription errors in the source — `clímax` is marked on `max`.)

Compounds are **included** in the gold: the lexicon transcribes one `ˈ` per compound and puts it on the last element, which is exactly where the primary belongs. Secondary stress is not transcribed anywhere in the dataset, so it is asserted by rule and *not* claimed as measured.

## API (additive)

```python
from silabificador import analyze, stressed_index

stressed_index("computador")    # 3  -> com.pu.ta.DOR

[str(s) for s in analyze("guarda-chuva") if s.stressed]    # ['chu']
[str(s) for s in analyze("guarda-chuva") if s.secondary]   # ['guar']
```

`Syllable` gains `stressed` and `secondary`. `syllabify()` is unchanged.

## Also

Drops the dev/test split from the benchmark. There is no training step here, so there is nothing to hold out: every word is scored and the full dataset is reported. Syllable numbers are unchanged (agreement 99.87%, Infopédia 99.34%, Portal 99.81%, 116,959/116,959 round-trip).

## Verification

`pytest` — 143 passed (32 new, one per stress rule and one per minimal pair). `python -m benchmark.report` prints the scoreboard, the gold self-check, and every wrong word.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Portuguese stress detection, including primary and secondary stress.
  * Added `stressed_index` to retrieve a word’s primary-stress syllable.
  * Stress information is now included in syllable analysis.
  * Added support for stress in hyphenated compounds and historical secondary-stress marks.
  * Added a stress demonstration example.

* **Documentation**
  * Expanded API, usage, stress rules, and accuracy documentation.

* **Tests**
  * Added comprehensive coverage for accents, compounds, clitics, and stress placement.
  * Updated benchmark reporting and gold-data validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->