### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,26 @@
-# 🧩 Silabificador
+# Silabificador
 
-A Portuguese syllabifier built from Portuguese phonotactics. Rule-based,
-dependency-free, no model to load.
+Silabificador splits a Portuguese word into syllables. It uses hand-crafted
+rules based on Portuguese phonotactics. It has no runtime dependencies and
+loads no model.
 
----
+## Features
 
-## 📦 Features
-
-- Syllabification for **Portuguese**, derived from the licit onset inventory and
-  the diphthong/hiatus rules rather than from a table of special cases.
-- **Stress**, primary and secondary, read out of the orthography that encodes it.
-- **Syllable structure**, not just strings: onset, glide, nucleus, coda.
-- The output **always reconstructs the input** — hyphens, spaces and apostrophes
-  are kept, never dropped.
+- Syllabification for Portuguese, derived from the licit onset inventory and
+  the diphthong/hiatus rules, not from a table of special cases.
+- Stress, primary and secondary, read from the orthography that encodes it.
+- Syllable structure, not just strings: onset, glide, nucleus, coda.
+- The output always reconstructs the input. Hyphens, spaces, and apostrophes
+  stay in place and are never dropped.
 - No dependencies.
 
----
-
-## 🚀 Installation
+## Installation
 
 ```bash
 pip install git+https://github.com/TigreGotico/silabificador
 ```
 
----
-
-## 🧠 Usage
+## Usage
 
 ```python
 from silabificador import syllabify
@@ -34,7 +29,7 @@ syllabify("computador")     # ['com', 'pu', 'ta', 'dor']
 syllabify("guarda-chuva")   # ['guar', 'da-', 'chu', 'va']
 ```
 
-Need the constituents, or the stress?
+Use `analyze` for the constituents, or `stressed_index` for the stress:
 
 ```python
 from silabificador import analyze, stressed_index
@@ -48,62 +43,70 @@ for s in analyze("transportar"):
 stressed_index("sílaba")   # 0   SÍ.la.ba
 ```
 
-A compound keeps a stress on every element — the last one takes the primary:
+A compound keeps a stress on every element. The last element takes the
+primary stress:
 
 ```python
 [str(s) for s in analyze("guarda-chuva") if s.secondary]   # ['guar']
 [str(s) for s in analyze("guarda-chuva") if s.stressed]    # ['chu']
 ```
 
-See [`docs/api.md`](docs/api.md) for the full surface and
+See [`docs/api.md`](docs/api.md) for the full API surface and
 [`docs/advanced.md`](docs/advanced.md) for the rules and the known limits.
 
----
+## Accuracy
 
-## 📊 Accuracy
+Silabificador is measured against the
+[Portuguese Unified Pronunciation Lexicon](https://huggingface.co/datasets/TigreGotico/portuguese-unified-pronunciation-lexicon).
+This lexicon carries syllabifications from two independent authorities:
+Infopédia (Porto Editora) and the Portal da Língua Portuguesa.
 
-Measured against the
-[Portuguese Unified Pronunciation Lexicon](https://huggingface.co/datasets/TigreGotico/portuguese-unified-pronunciation-lexicon),
-which carries syllabifications from two independent authorities — Infopédia
-(Porto Editora) and the Portal da Língua Portuguesa.
-
-The **gold** is the set of words the two sources *independently agree on*
-(35,181), after discarding any entry whose syllables do not reconstruct its
-headword. Every word is scored — no sampling, no caps.
+The gold set is the set of words the two sources independently agree on
+(35,181 words), after discarding any entry whose syllables do not reconstruct
+its headword. Every word is scored. There is no sampling and no cap.
 
 | set | exact match | |
 |---|---|---|
-| **agreement (gold)** | **99.87%** | 35,137 / 35,181 |
+| agreement (gold) | 99.87% | 35,137 / 35,181 |
 | Infopédia | 99.34% | 99,619 / 100,279 |
 | Portal | 99.81% | 51,763 / 51,861 |
 
-Every one of the 116,959 scoreable words reconstructs exactly.
+All 116,959 scoreable words reconstruct exactly.
 
-Where the two authorities *disagree* (135 words — on morpheme boundaries, and on
-etymological hiatus) neither answer is scored against, because there is no fact
-of the matter to be right about.
+Where the two authorities disagree (135 words, on morpheme boundaries and on
+etymological hiatus), the tool scores against neither answer, because there
+is no fact of the matter to be right about.
 
-**Stress** is measured against a gold the engine cannot see: the lexicon's IPA
+Stress is measured against a gold the engine cannot see: the lexicon's IPA
 transcriptions, which mark stress with `ˈ`. Nothing in the engine reads IPA.
 
 | | | |
 |---|---|---|
-| stress accuracy | **99.83%** | 43,819 / 43,893 |
+| stress accuracy | 99.83% | 43,819 / 43,893 |
 | gold self-check | 99.75% | 4,712 / 4,724 |
 
-The self-check is the reason to trust the gold: on a simple word, a written
-accent *is* the stress, by definition of the spelling rules — so the IPA-derived
-answer had better agree with it, and it does.
+The self-check gives a reason to trust the gold: on a simple word, a written
+accent is the stress, by definition of the spelling rules, so the IPA-derived
+answer must agree with it, and it does.
 
-Reproduce it, and see every remaining failure bucketed by cause:
+To reproduce the accuracy numbers and see every remaining failure bucketed by
+cause, run:
 
 ```bash
 pip install -e ".[benchmark]"
 python -m benchmark.report
 ```
 
----
+## Related projects
 
-## 📄 License
+Silabificador is part of the [TigreGotico](https://github.com/TigreGotico)
+Portuguese phonetics toolchain, alongside:
+
+- [orthography2ipa](https://github.com/TigreGotico/orthography2ipa)
+- [tugaphone](https://github.com/TigreGotico/tugaphone)
+- [bifonia](https://github.com/TigreGotico/bifonia)
+- [g2p_barranquenho](https://github.com/TigreGotico/g2p_barranquenho)
+
+## License
 
 MIT License

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -1,11 +1,12 @@
 # Advanced
 
-How the split is decided, and where it is known to be wrong.
+This page explains how the split is decided, and where it is known to be
+wrong.
 
 ## The shape of the engine
 
-Four layers. Each one can be read, tested and corrected without touching the
-others.
+The engine has four layers. Each layer can be read, tested, and corrected
+without touching the others.
 
 ```
 phonotactics   what Portuguese licenses (data: onsets, glides, accents)
@@ -23,9 +24,9 @@ stress         which syllable bears the stress
 
 ## Layer 1 — digraphs are decided in context
 
-Portuguese spelling is not one letter per segment. `lh` is a single consonant, and
-so is the `qu` of *quero*, whose `u` spells nothing at all. But the `u` of *agudo*
-is a full vowel, and the letters are the same.
+Portuguese spelling does not use one letter per segment. `lh` is a single
+consonant, and so is the `qu` of *quero*, whose `u` spells nothing at all.
+But the `u` of *agudo* is a full vowel, and the letters are the same.
 
 ```python
 syllabify("quero")     # ['que', 'ro']   -- qu is one consonant, u is silent
@@ -34,40 +35,41 @@ syllabify("agudo")     # ['a', 'gu', 'do'] -- u is a nucleus
 syllabify("linguiça")  # ['lin', 'gui', 'ça']
 ```
 
-The rule: after `q`/`g`, a `u` immediately followed by another vowel never heads a
-syllable. A `u` followed by a consonant keeps its nucleus. The digraph is decided
-per occurrence, from what follows it.
+The rule: after `q`/`g`, a `u` immediately followed by another vowel never
+heads a syllable. A `u` followed by a consonant keeps its nucleus. The
+engine decides the digraph per occurrence, from what follows it.
 
 ## Layer 2 — a vowel pair has no answer of its own
 
-Asking whether `ai` is a diphthong is asking the wrong question. It is one in
-*pai* and not one in *ainda*. Each row below is a **minimal pair**: same vowels,
+Asking whether `ai` is a diphthong asks the wrong question. It is one in
+*pai* and not one in *ainda*. Each row below is a minimal pair: same vowels,
 opposite split.
 
 | diphthong | hiatus | what decides |
 |---|---|---|
 | `pais` | `pa.ís` | an accent pins a close vowel as a nucleus |
-| `pais`, `mais`, `de.pois` | `a.in.da`, `ca.ir`, `ju.iz`, `ru.im` | a coda `l m n r z` blocks the diphthong — `s`/`x` do not |
+| `pais`, `mais`, `de.pois` | `a.in.da`, `ca.ir`, `ju.iz`, `ru.im` | a coda `l m n r z` blocks the diphthong; `s`/`x` do not |
 | `bai.le` | `ra.i.nha`, `mo.i.nho` | a following `nh` pulls the vowel into its own syllable |
-| `bair.ro` | `ca.ir` | a geminate `rr` spells *one* consonant, so it closes nothing |
+| `bair.ro` | `ca.ir` | a geminate `rr` spells one consonant, so it closes nothing |
 | `mãe`, `pão`, `põe` | `co.e.lho` | a nasal nucleus licenses a mid offglide; a plain one does not |
 
-Rising sequences (`su.a`, `his.tó.ri.a`, `co.e.lho`) need **no rule**: Portuguese
-has no mid or low glides, so a vowel that is not `i`/`u` is always a nucleus, and
-hiatus falls out for free.
+Rising sequences (`su.a`, `his.tó.ri.a`, `co.e.lho`) need no rule: Portuguese
+has no mid or low glides, so a vowel that is not `i`/`u` is always a
+nucleus, and hiatus follows for free.
 
-Triphthongs need no rule either. In *quais* and *Uruguai* the leading glide is
-spelled inside the `qu`/`gu` onset, so layer 1 has already absorbed it, and what
-reaches layer 2 is a plain nucleus with one offglide.
+Triphthongs need no rule either. In *quais* and *Uruguai* the leading glide
+is spelled inside the `qu`/`gu` onset, so layer 1 has already absorbed it,
+and what reaches layer 2 is a plain nucleus with one offglide.
 
 ## Layer 3 — one principle for consonants
 
-**Onset maximization, bounded by the licit onset inventory.** A consonant cluster
-between two nuclei gives as much of its right edge to the next onset as Portuguese
-allows; the rest is stranded in the coda. Complex onsets in Portuguese are exactly
-*obstruent + liquid*.
+Onset maximization, bounded by the licit onset inventory. A consonant
+cluster between two nuclei gives as much of its right edge as possible to
+the next onset, within what Portuguese allows. The rest stays in the coda.
+Complex onsets in Portuguese are exactly *obstruent + liquid*.
 
-That single fact derives all of these — none of them is stated anywhere:
+That single fact derives all of these results, and none of them is stated
+anywhere else:
 
 ```python
 syllabify("atleta")     # ['a', 'tle', 'ta']    tl is licit
@@ -76,14 +78,16 @@ syllabify("carro")      # ['car', 'ro']         rr is not; likewise ss, sc, xc
 syllabify("abstrair")   # ['abs', 'tra', 'ir']  tr is licit, str is not
 ```
 
-Codas are deliberately **not** an inventory. Portuguese spelling admits whatever
-the onset rule strands — *ap.to*, *rit.mo*, *ab.sur.do*, *sof.twa.re* — so
-constraining the coda as well would only reject words the dictionaries spell.
+The engine does not treat codas as an inventory. Portuguese spelling admits
+whatever the onset rule strands, for example *ap.to*, *rit.mo*, *ab.sur.do*,
+*sof.twa.re*. Constraining the coda too would reject words the dictionaries
+spell.
 
 ## The lexical layer, and why it exists
 
-Some words cannot be reached by any rule, because what decides them is whether a
-morpheme is still *felt* in the word — a fact about its history, not its spelling:
+Some words cannot be reached by any rule, because what decides them is
+whether a morpheme is still felt in the word, a fact about its history, not
+its spelling:
 
 ```
 sub.li.mi.nar     but   su.bli.me      (sublimis is one morpheme)
@@ -91,16 +95,18 @@ ab.le.gar         but   a.bran.dar     (brandar, not ab + randar)
 dis.tri.bu.i.dor  but   cui.da.do      (cuidado has no seam in it)
 ```
 
-`silabificador.morphology` holds a small lexicon for these. It stores
-**morphemes, not answers**: it says *sublocar is sub + locar*, and the ordinary
-rules then derive `sub.lo.car`. One `loc` entry covers *sublocar, sublocação,
-sublocatário, sublocador* — including words nobody tested.
+`silabificador.morphology` holds a small lexicon for these cases. It stores
+morphemes, not answers: it records that *sublocar* is *sub* + *locar*, and
+the ordinary rules then derive `sub.lo.car`. One `loc` entry covers
+*sublocar, sublocação, sublocatário, sublocador*, including words nobody
+tested.
 
 ## Stress
 
-Portuguese stress is not guessed at. The orthography is *designed* to encode it:
-an accent is obligatory on any word whose stress departs from the default, so the
-accent is not a hint, it is a statement — and its **absence** is a statement too.
+Portuguese stress is not guessed at. The orthography is designed to encode
+it: an accent is obligatory on any word whose stress departs from the
+default, so the accent is not a hint, it is a statement, and its absence is
+a statement too.
 
 ```
 1. ACCENT    a syllable with an acute or circumflex is the stressed one
@@ -110,47 +116,53 @@ accent is not a hint, it is a statement — and its **absence** is a statement t
              paroxytone: everything else, and -as -es -os -am -em -ens
 ```
 
-Rule 3 is a two-way choice, not a guess: an unaccented word *cannot* be
-proparoxytone, because the spelling rules would have required an accent to say
-so. That is why `sá.bi.a`, `sa.bi.a` and `sa.bi.á` are three words.
+Rule 3 is a two-way choice, not a guess: an unaccented word cannot be
+proparoxytone, because the spelling rules would have required an accent to
+say so. That is why `sá.bi.a`, `sa.bi.a`, and `sa.bi.á` are three different
+words.
 
 ### Secondary stress
 
-A hyphenated compound is two words wearing one coat, and each element keeps the
-stress it had alone. The last element takes the primary; the earlier ones are
-demoted to secondary:
+A hyphenated compound is two words wearing one coat, and each element keeps
+the stress it had alone. The last element takes the primary stress; the
+earlier ones are demoted to secondary:
 
 ```python
 [str(s) for s in analyze("guarda-chuva") if s.secondary]   # ['guar']
 [str(s) for s in analyze("guarda-chuva") if s.stressed]    # ['chu']
 ```
 
-An element that is an unstressed monosyllable carries nothing. Portuguese grammar
-names that class — the *monossílabos átonos* (articles, prepositions,
-conjunctions, clitic pronouns) — and it is closed, so it is listed rather than
-guessed: in `chapéu de chuva`, the `de` is one of them.
+An element that is an unstressed monosyllable carries nothing. Portuguese
+grammar names that class, the *monossílabos átonos* (articles,
+prepositions, conjunctions, clitic pronouns), and it is a closed class, so
+the engine lists it rather than guessing it: in `chapéu de chuva`, `de` is
+one of them.
 
-Before 1990 a grave accent marked secondary stress (`sòmente`, `cafèzinho`). It is
-still honoured where it appears. The grave on `à` is *not* a stress mark — it is
-crasis, and it is unstressed.
+Before 1990, a grave accent marked secondary stress (`sòmente`, `cafèzinho`).
+The engine still honors it where it appears. The grave on `à` is not a
+stress mark; it is crasis, and it is unstressed.
 
-**The secondary stress of `-mente` and `-zinho` words is not marked.** `rapidamente`
-comes from `rápida`, but the suffix drops the base's accent, and nothing left in
-the spelling says where `rápida` was stressed. Recovering it needs a lexicon of
-bases, which this library does not carry.
+The secondary stress of `-mente` and `-zinho` words is not marked.
+`rapidamente` comes from `rápida`, but the suffix drops the base's accent,
+and nothing left in the spelling says where `rápida` was stressed.
+Recovering it needs a lexicon of bases, which this library does not carry.
 
 ## Known limits
 
-**The productive prefixes are not implemented** — `ciber-`, `hiper-`, `super-`,
+The productive prefixes are not implemented: `ciber-`, `hiper-`, `super-`,
 `inter-`. Infopédia often keeps them intact (`ci.ber.as.sé.di.o`,
-`hi.per.es.pe.ci.a.li.zar`) but not consistently — it also writes
-`hi.pe.ra.gu.do` and `a.dre.na.li.na` beside `ad.re.nal` — and the Portal da
-Língua Portuguesa never does. The two authorities disagree, so there is no fact
-to encode. This is the largest single class of residual mismatch against
-Infopédia.
+`hi.per.es.pe.ci.a.li.zar`) but not consistently. It also writes
+`hi.pe.ra.gu.do` and `a.dre.na.li.na` beside `ad.re.nal`, and the Portal da
+Língua Portuguesa never splits them this way. The two authorities disagree,
+so there is no fact to encode. This is the largest single class of residual
+mismatch against Infopédia.
 
-**Foreign onsets are not in the inventory.** `sof.twa.re` is written `soft.wa.re`,
-because `tw` is not a Portuguese onset. Roughly 20 loanwords in the lexicon.
+Foreign onsets are not in the inventory. `sof.twa.re` is written
+`soft.wa.re`, because `tw` is not a Portuguese onset. The lexicon has
+roughly 20 such loanwords.
 
-Both classes are counted, not hidden: `python -m benchmark.report` prints every
-failure bucketed by cause.
+The engine counts both classes rather than hiding them: `python -m
+benchmark.report` prints every remaining failure bucketed by cause.
+
+---
+[← API Reference](api.md) · [Home](../README.md)

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,7 +1,7 @@
 # API Reference
 
-Everything importable from `silabificador`. Signatures and return shapes are
-exactly as implemented.
+This page lists everything importable from `silabificador`. Signatures and
+return shapes match the implementation exactly.
 
 ## `syllabify`
 
@@ -11,11 +11,11 @@ from silabificador import syllabify
 syllabify(word: str) -> List[str]
 ```
 
-Divide a Portuguese word into syllables.
+Divides a Portuguese word into syllables.
 
-- **word** — a Portuguese word. Case is normalized to lowercase; leading and
-  trailing whitespace is stripped.
-- **returns** — a list of syllable strings in order.
+- **word**: a Portuguese word. The function normalizes case to lowercase and
+  strips leading and trailing whitespace.
+- **returns**: a list of syllable strings, in order.
 
 ```python
 syllabify("computador")     # ['com', 'pu', 'ta', 'dor']
@@ -23,8 +23,8 @@ syllabify("Brasil")         # ['bra', 'sil']
 syllabify("português")      # ['por', 'tu', 'guês']
 ```
 
-**`"".join(result)` always reconstructs the lowercased input.** A hyphen, space
-or apostrophe is kept on the syllable it follows, never dropped:
+`"".join(result)` always reconstructs the lowercased input. A hyphen, space,
+or apostrophe stays on the syllable it follows, and is never dropped:
 
 ```python
 syllabify("guarda-chuva")       # ['guar', 'da-', 'chu', 'va']
@@ -33,7 +33,8 @@ syllabify("pau-d'água")         # ['pau-', "d'á", 'gua']
 syllabify("ajudante de campo")  # ['a', 'ju', 'dan', 'te ', 'de ', 'cam', 'po']
 ```
 
-A word with no vowel in it has no syllable to find, and is returned whole:
+A word with no vowel in it has no syllable to find, and the function returns
+it whole:
 
 ```python
 syllabify("psst")   # ['psst']
@@ -49,8 +50,8 @@ analyze(word: str) -> List[Syllable]
 ```
 
 The same split, with each syllable decomposed. Use it when you need the
-constituents — a phonemizer, a stress rule, a rhyme index — rather than the
-strings.
+constituents, for example in a phonemizer, a stress rule, or a rhyme index,
+rather than the plain strings.
 
 ```python
 for s in analyze("transportar"):
@@ -68,7 +69,7 @@ from silabificador import stressed_index
 stressed_index(word: str) -> int
 ```
 
-The index of the syllable carrying the primary stress.
+Returns the index of the syllable that carries the primary stress.
 
 ```python
 stressed_index("computador")   # 3   com.pu.ta.DOR
@@ -83,22 +84,29 @@ A frozen dataclass.
 | field | meaning |
 |---|---|
 | `onset` | consonants before the nucleus (`tr`, `qu`, `lh`) |
-| `glide_on` | the glide spelled *inside* a `qu`/`gu` onset — the `u` of *qua*dro |
+| `glide_on` | the glide spelled inside a `qu`/`gu` onset, for example the `u` of *qua*dro |
 | `nucleus` | the vowel that heads the syllable |
-| `glide_off` | the offglide of a falling diphthong — the `i` of p*ai* |
+
+| field | meaning |
+|---|---|
+| `glide_off` | the offglide of a falling diphthong, for example the `i` of p*ai* |
 | `coda` | consonants after the nucleus |
-| `separator` | a hyphen, space or apostrophe held by this syllable |
+| `separator` | a hyphen, space, or apostrophe held by this syllable |
+
+| field | meaning |
+|---|---|
 | `surface` | the syllable as written |
-| `stressed` | carries the word's primary stress — exactly one syllable does |
-| `secondary` | carries a secondary stress (compounds only) |
+| `stressed` | true for the syllable that carries the word's primary stress. Exactly one syllable does |
+| `secondary` | true for a syllable that carries a secondary stress (compounds only) |
 
-`str(syllable)` returns `surface`. It is stored rather than recomposed from the
-fields, because a separator can sit anywhere inside a syllable (`ra-d'`) and
-reassembling in onset-nucleus-coda order would reorder the letters.
+`str(syllable)` returns `surface`. The class stores this value rather than
+recomposing it from the fields, because a separator can sit anywhere inside a
+syllable (`ra-d'`), and reassembling in onset-nucleus-coda order would
+reorder the letters.
 
-`glide_on` is *reported, not additive*: it is already inside `onset`, since the
-`u` of `qu` is part of that digraph. `str(analyze("quadro")[0])` is `"qua"`, not
-`"quuа"`.
+`glide_on` is reported, not additive: it is already part of `onset`, because
+the `u` of `qu` belongs to that digraph. `str(analyze("quadro")[0])` returns
+`"qua"`, not `"quuа"`.
 
 ## `Syllabifier`
 
@@ -110,18 +118,24 @@ s.syllabify("computador")   # ['com', 'pu', 'ta', 'dor']
 s.analyze("casa")           # [Syllable(onset='c', ...), ...]
 ```
 
-A stateless wrapper; there is nothing to configure and no model to load.
+A stateless wrapper. There is nothing to configure, and it loads no model.
 
 ## The layers
 
-The engine is four modules, each with one job. They are importable, and reading
-them is the documentation of the rules:
+The engine has four modules, each with one job. They are importable, and
+reading them documents the rules directly.
 
 | module | job |
 |---|---|
-| `silabificador.phonotactics` | what Portuguese licenses — data only, no logic |
-| `silabificador.graphemes` | orthography → grapheme units (layer 1) |
+| `silabificador.phonotactics` | what Portuguese licenses: data only, no logic |
+| `silabificador.graphemes` | orthography to grapheme units (layer 1) |
 | `silabificador.nucleus` | nucleus and glide resolution (layer 2) |
+
+| module | job |
+|---|---|
 | `silabificador.morphology` | morpheme boundaries, which outrank the rules |
 | `silabificador.parser` | syllable assembly (layer 3) |
 | `silabificador.stress` | which syllable bears the stress |
+
+---
+[← Quickstart](quickstart.md) · [Home](../README.md) · [Next →](advanced.md)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,8 +1,8 @@
-# Quickstart — zero to hero
+# Quickstart
 
-`silabificador` splits a Portuguese word into syllables. One function, pure
-Python, no runtime dependencies. If you can call `str.split`, you already know
-the shape of the API.
+`silabificador` splits a Portuguese word into syllables. It is one function,
+pure Python, with no runtime dependencies. If you can call `str.split`, you
+already know the shape of the API.
 
 ## 1. Install
 
@@ -16,13 +16,13 @@ From a checkout:
 pip install -e .
 ```
 
-Requires Python >= 3.7. Nothing else — the algorithm is hand-crafted rules, no
-models to download.
+This requires Python 3.7 or later. Nothing else is needed. The algorithm is a
+set of hand-crafted rules, and there are no models to download.
 
 ## 2. The one thing to understand
 
 `syllabify(word)` takes one word and returns a list of syllable strings, in
-order. Accents and digraphs are preserved exactly as written.
+order. It preserves accents and digraphs exactly as written.
 
 ```python
 from silabificador import syllabify
@@ -31,8 +31,7 @@ print(syllabify("computador"))
 # ['com', 'pu', 'ta', 'dor']
 ```
 
-The returned syllables join back into the input (lowercased): `"".join(...)`
-reconstructs the word.
+`"".join(...)` on the returned syllables reconstructs the word (lowercased).
 
 ```python
 word = "português"
@@ -44,7 +43,7 @@ print(len(syls))         # 3  -> syllable count
 
 ## 3. Real Portuguese, real splits
 
-The rules handle the structures that make Portuguese tricky — consonant
+The rules handle the structures that make Portuguese tricky: consonant
 clusters, diphthongs, hiatus, nasal vowels, and the inseparable digraphs
 (`ch`, `lh`, `nh`, `gu`, `qu`).
 
@@ -64,7 +63,7 @@ syllabify("carro")        # ['car', 'ro']     'rr' splits across the boundary
 ## 4. The class wrapper
 
 If you prefer an object, `Syllabifier` exposes the same call as a method. It
-holds no state — it is a thin handle over `syllabify`.
+holds no state. It is a thin handle over `syllabify`.
 
 ```python
 from silabificador import Syllabifier
@@ -73,12 +72,12 @@ s = Syllabifier()
 print(s.syllabify("caça"))   # ['ca', 'ça']
 ```
 
-Use the bare `syllabify` function unless an interface in your code expects an
-object with a `.syllabify` method.
+Use the bare `syllabify` function, unless an interface in your code expects
+an object with a `.syllabify` method.
 
 ## 5. Counting and joining
 
-Because the output is a plain list, everything you do with lists works:
+Because the output is a plain list, everything you do with lists works.
 
 ```python
 from silabificador import syllabify
@@ -92,5 +91,8 @@ print("hyphenated:", "-".join(syls))   # ex-tra-or-di-ná-ri-o
 
 ## Where next
 
-- [api.md](api.md) — every public symbol, real signatures, return shapes
-- [advanced.md](advanced.md) — digraphs, diphthong vs. hiatus, batch use, gotchas
+- [api.md](api.md) — every public symbol, with real signatures and return shapes
+- [advanced.md](advanced.md) — digraphs, diphthong vs. hiatus, batch use, and known gotchas
+
+---
+[Home](../README.md) · [Next →](api.md)


### PR DESCRIPTION
Rewrites README.md and docs/*.md for clarity, using Simplified Technical English (STE-flavored mode). Facts, code examples, and the accuracy tables are unchanged. Adds a footer navigation trail across the three docs pages and a related-projects section linking sibling repos in the org.

Rewritten with Claude Fable 5 using the ste-writing skill; linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined the README with clearer feature, installation, usage, accuracy, related projects, and license sections.
  * Expanded guidance for constituent analysis, stress detection, compound stress behavior, and benchmark reproduction.
  * Improved API reference descriptions, quickstart instructions, and advanced documentation formatting and navigation.
  * Clarified syllable reconstruction, accent and digraph preservation, engine behavior, and known limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->